### PR TITLE
Add Trust Store Program Locations and additional trust stores.

### DIFF
--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -41,15 +41,16 @@ Then in the list of certificates you choose the one from Federal Common Policy C
 In the Policies tab you can find “Policy Restrictions” with the comma separated list of OIDs in Certificate Policies.
  
 This is the current list for Federal **COMMON** Policy CA:
-| Common Policy                                 | Common OID                | Certificate Use                                                                   |
+
+Common Policy                                 | Common OID                | Certificate Use                                                                   |
 |-----------------------------------------------|---------------------------|-----------------------------------------------------------------------------------|
 | Common Hardware                               | 2.16.840.1.101.3.2.1.3.7  | PIV and Federal Bridge Medium Hardware Token                                      |
-| FBCA Medium Hardware Commercial Best Practice* | 2.16.840.1.101.3.2.1.3.15 | Federal Bridge Medium Hardware Token (PKI Trusted Roles may not be U.S. Citizens) |
+| Federal Bridge Medium Hardware Commercial Best Practice* | 2.16.840.1.101.3.2.1.3.15 | Federal Bridge Medium Hardware Token (PKI Trusted Roles may not be U.S. Citizens) |
 | Common High                                   | 2.16.840.1.101.3.2.1.3.16 | High Assurance Policy                                                             |
 | PIV-I Hardware                                | 2.16.840.1.101.3.2.1.3.18 | PIV-I                                                                             |
 | SHA-1 Hardware                                | 2.16.840.1.101.3.2.1.3.24 | CAC and SHA-1 Medium Hardware Tokens through SHA-1 Federal Root CA                |
 
-*Note: Commercial Best Practice (CBP) are issued against the same policy requirements as Federal Bridge Medium Hardware except the trusted roles who issue the certificates may not be U.S. Citizens.
+>**Note:** Commercial Best Practice (CBP) are issued against the same policy requirements as Federal Bridge Medium Hardware except the trusted roles who issue the certificates may not be U.S. Citizens.
 
 ## How do I set dynamic path validation in Windows operating systems?
 

--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -34,6 +34,19 @@ Google|No|Google Admin Console|Chrome Browser, Android, and ChromiumOS|https://w
 
 TODO:  Add the info from the trust store guide from FPKI
 
+## How do I check which FPKI certificate policies are trusted by Adobe?
+
+You can read it in Acrobat by opening the Preferences > Signatures > Identities & Trusted Certificates > Trusted Certificates.
+Then in the list of certificates you choose the one from Federal Common Policy CA and select “Certificate details”.
+In the Policies tab you can find “Policy Restrictions” with the comma separated list of OIDs in Certificate Policies.
+ 
+This is the current list for Federal **COMMON** Policy CA:
+2.16.840.1.101.3.2.1.3.7
+2.16.840.1.101.3.2.1.3.15
+2.16.840.1.101.3.2.1.3.16
+2.16.840.1.101.3.2.1.3.18
+2.16.840.1.101.3.2.1.3.24
+
 ## How do I set dynamic path validation in Windows operating systems?
 
 Dynamic path validation differs from static in that the certificate validation software will build the

--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -19,14 +19,14 @@ Operating systems, browsers, and some commercial software use trust stores to ve
 There are four trust stores you will most often interact with.
 
 Application Trust Store|Includes COMMON?|Trust Store Manager|Platforms serviced|Program Information Location
----|---|---|---
+---|---|---|---|---
 Microsoft Root Certificate Program|Yes|Microsoft Management Console|Windows OS, Internet Explorer Browser, Outlook|http://aka.ms/RootCert
 Apple Root Certificate Program|Yes|Keychain Access utility|iOS, WatchOS, OS X, Safari Browser|https://www.apple.com/certificateauthority/ca_program.html
-Mozilla Network Security Services(NSS)|No (application in progress)|Browser Specific|Firefox, Thunderbird, Linux Operating Systems|https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/
-Adobe Approved Trust List|Yes|Trust Store Manager|Adobe Acrobat|https://www.apple.com/certificateauthority/ca_program.html
+Mozilla Network Security Services (NSS)|No (application in progress)|Browser Trust Store|Firefox, Thunderbird, Linux Operating Systems|https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/
+Adobe Approved Trust List|Yes|Application Trust Store|Adobe Acrobat|https://www.apple.com/certificateauthority/ca_program.html
 Java Root Certificate Program|No (pending application)|Java Applet|Java Distributions|http://www.oracle.com/technetwork/java/javase/javasecarootcertsprogram-1876540.html
-Opera|No longer operates its own program and relies upon Mozilla.
 Google|No|Google Admin Console|Chrome Browser, Android, and ChromiumOS|https://www.chromium.org/Home/chromium-security/root-ca-policy
+Opera|No longer operates its own program and relies upon Mozilla.
 
 >**Note:** Google Chrome uses the underlying trust library of the operating system on Windows or Apple OS X systems.  Linux-based systems distribute the Mozilla NSS Library which may be modified by each version of Linux. Google is working on developing its own program similar to Mozilla.
 

--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -41,11 +41,15 @@ Then in the list of certificates you choose the one from Federal Common Policy C
 In the Policies tab you can find “Policy Restrictions” with the comma separated list of OIDs in Certificate Policies.
  
 This is the current list for Federal **COMMON** Policy CA:
-2.16.840.1.101.3.2.1.3.7
-2.16.840.1.101.3.2.1.3.15
-2.16.840.1.101.3.2.1.3.16
-2.16.840.1.101.3.2.1.3.18
-2.16.840.1.101.3.2.1.3.24
+| Common Policy                                 | Common OID                | Certificate Use                                                                   |
+|-----------------------------------------------|---------------------------|-----------------------------------------------------------------------------------|
+| Common Hardware                               | 2.16.840.1.101.3.2.1.3.7  | PIV and Federal Bridge Medium Hardware Token                                      |
+| FBCA Medium Hardware Commercial Best Practice* | 2.16.840.1.101.3.2.1.3.15 | Federal Bridge Medium Hardware Token (PKI Trusted Roles may not be U.S. Citizens) |
+| Common High                                   | 2.16.840.1.101.3.2.1.3.16 | High Assurance Policy                                                             |
+| PIV-I Hardware                                | 2.16.840.1.101.3.2.1.3.18 | PIV-I                                                                             |
+| SHA-1 Hardware                                | 2.16.840.1.101.3.2.1.3.24 | CAC and SHA-1 Medium Hardware Tokens through SHA-1 Federal Root CA                |
+
+*Note: Commercial Best Practice (CBP) are issued against the same policy requirements as Federal Bridge Medium Hardware except the trusted roles who issue the certificates may not be U.S. Citizens.
 
 ## How do I set dynamic path validation in Windows operating systems?
 

--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -4,28 +4,31 @@ title: Trust Stores
 permalink: /truststores/
 ---
 
-This guide provides a high-level overview of what trust stores are, a list of commonly used trust stores, and where to find them.
+This guide provides a high-level overview of what application trust stores are, a list of commonly used application trust stores, and where to find them.
 
-## What is a Trust Store?
-There are millions of identity certificates in the world currently, and the list constantly changes as some certificates are revoked and others are issued - far too many for your computer to maintain an up to date list.  
+## What is an Application Trust Store?
+There are millions of identity (certificates issued to People) and device certificates in the world currently, and the list constantly changes as some certificates are revoked and others are issued - far too many for your computer to maintain an up to date list.  
 
-Instead, your system keeps a list of **root** certificates which it trusts.  When you are presented with an identity certificate from a PIV credential, website, email, or some other digital item, your system will check to see if the certificate chains to one of the trusted **roots**.  
+Instead, applications keeps a list of **root** certificates which it trusts to issue certificates.  When you are presented with an identity or device certificate from a PIV credential, website, email, or some other digital item, your system or application will check to see if the certificate chains to one of the trusted **roots** in the application trust store. The trust store may maintain an indepenet list of trusted root certificates which comply with the individual trust store requirements. 
 
-This list of trusted root certificates is known as a **Trust Store.**
+This list of trusted root certificates are contained within what is known as a **Trust Store** in either an application or operating system. 
 
-## What are commonly used Trust Stores?
+## What are commonly used Application Trust Stores?
 Operating systems, browsers, and some commercial software use trust stores to verify whether the certificate you are being presented should be trusted.  
 
 There are four trust stores you will most often interact with.
 
-Trust Store|Includes COMMON?|Trust Store Manager|Platforms serviced
+Application Trust Store|Includes COMMON?|Trust Store Manager|Platforms serviced|Program Information Location
 ---|---|---|---
-Microsoft Root Certificate Program|Yes|Microsoft Management Console|Windows OS, Internet Explorer Browser, Outlook
-Apple Root Certificate Program|Yes|Keychain Access utility|OS X, Safari Browser
-Mozilla Network Security Services(NSS)|No (application in progress)|Browser Specific|Firefox, Thunderbird
-Adobe Address Book|Yes|Trust Store Manager|Adobe Acrobat
+Microsoft Root Certificate Program|Yes|Microsoft Management Console|Windows OS, Internet Explorer Browser, Outlook|http://aka.ms/RootCert
+Apple Root Certificate Program|Yes|Keychain Access utility|iOS, WatchOS, OS X, Safari Browser|https://www.apple.com/certificateauthority/ca_program.html
+Mozilla Network Security Services(NSS)|No (application in progress)|Browser Specific|Firefox, Thunderbird, Linux Operating Systems|https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/
+Adobe Approved Trust List|Yes|Trust Store Manager|Adobe Acrobat|https://www.apple.com/certificateauthority/ca_program.html
+Java Root Certificate Program|No (pending application)|Java Applet|Java Distributions|http://www.oracle.com/technetwork/java/javase/javasecarootcertsprogram-1876540.html
+Opera|No longer operates its own program and relies upon Mozilla.
+Google|No|Google Admin Console|Chrome Browser, Android, and ChromiumOS|https://www.chromium.org/Home/chromium-security/root-ca-policy
 
->**Note:** Google Chrome uses the underlying trust library of the operating system on Windows or Apple OS X systems.  Linux-based systems don't have a default trust library built-in, in which case Chrome will use the Mozilla NSS library.
+>**Note:** Google Chrome uses the underlying trust library of the operating system on Windows or Apple OS X systems.  Linux-based systems distribute the Mozilla NSS Library which may be modified by each version of Linux. Google is working on developing its own program similar to Mozilla.
 
 ## How do I manage a Trust Store?
 


### PR DESCRIPTION
Added location of trust program page and added more information around trust needs. Need to do one more update to identify which trust stores trust which types of certificates. Not all trust stores trust all (i.e. Mozilla only enables Server Auth or SMIME, Adobe only enables digital signature.) Resolve #46.