### PR TITLE
New fpki_glossary with links

### DIFF
--- a/pages/fpki_glossary.md
+++ b/pages/fpki_glossary.md
@@ -6,473 +6,69 @@ permalink: /glossary/
 
 ## Glossary ##
 
-Below is a list of terms that are frequently used in the FPKI community. Please consider contributing any additional items that are missing from this list!
-
-[A](#a) - [B](#b) - [C](#c) - [D](#d) - [E](#e) - [F](#f) - [H](#h) - [I](#i) - [K](#k) - [L](#l) - [M](#m) - [N](#n) - [O](#o) - [P](#p) - [R](#r) - [S](#s) - [T](#t) - [U](#u) - [Z](#z)
-
-## A
-[*Back to top*](#glossary)
-
-**Access**
-
-: Ability to make use of any information system (IS) resource. 
-
-**Access Control**
-
-: Process of granting access to information system resources only to authorized users, programs, processes, or other systems. 
-
-**Accreditation**
-
-: Formal declaration by a Designated Approving Authority that an Information System is approved to operate in a particular security mode using a prescribed set of safeguards at an acceptable level of risk. 
-
-**Activation Data**
-
-: Private data, other than keys, that are required to access cryptographic modules (i.e., unlock private keys for signing or decryption events).
-
-**Affiliated Organization**
-
-: Organizations that authorize affiliation with Subscribers of PIV-I certificates.
-
-**Applicant**
-
-: The subscriber is sometimes also called an "applicant" after applying to a certification authority for a certificate, but before the certificate issuance procedure is completed.
-
-**Archive**
-
-: Long-term, physically separate storage.
-
-**Attribute Authority**
-
-: An entity, recognized by the FPKIPA or comparable Entity body as having the authority to verify the association of attributes to an identity.
-
-**Audit**
-
-: Independent review and examination of records and activities to assess the adequacy of system controls, to ensure compliance with established policies and operational procedures, and to recommend necessary changes in controls, policies, or procedures. 
-
-**Audit Data**
-
-: Chronological record of system activities to enable the reconstruction and examination of the sequence of events and changes in an event.
-
-**Authenticate**
-
-: To confirm the identity of an entity when that identity is presented.
-
-**Authentication**
-
-: Security measure designed to establish the validity of a transmission, message, or originator, or a means of verifying an individual's authorization to receive specific categories of information. 
-
-## B
-[*Back to top*](#glossary)
-
-**Backup**
-
-: Copy of files and programs made to facilitate recovery if necessary. 
-
-**Binding**
-
-: Process of associating two related elements of information. 
-
-**Biometric**
-
-: A physical or behavioral characteristic of a human being.
-
-## C
-[*Back to top*](#glossary)
-
-**Certificate**
-
-: A digital representation of information which at least (1) identifies the certification authority issuing it, (2) names or identifies its subscriber, (3) contains the subscriber's public key, (4) identifies its operational period, and (5) is digitally signed by the certification authority issuing it. As used in this CP, the term “Certificate” refers to certificates that expressly reference the OID of this CP in the “Certificate Policies” field of an X.509 v.3 certificate.
-
-**Certification Authority (CA)**
-
-: An authority trusted by one or more users to issue and manage X.509 Public Key Certificates and CARLs or CRLs.
-
-**Certification Authority Revocation List (CARL)**
-
-: A signed, time-stamped list of serial numbers of CA public key certificates, including cross-certificates, that have been revoked.
-
-**CA Facility**
-
-: The collection of equipment, personnel, procedures and structures that are used by a Certification Authority to perform certificate issuance and revocation.
-
-**Certificate**
-
-: A digital representation of information which at least (1) identifies the certification authority issuing it, (2) names or identifies it’s Subscriber, (3) contains the Subscriber’s public key, (4) identifies it’s operational period, and (5) is digitally signed by the certification authority issuing it.
-
-**Certificate Management Authority (CMA)**
-
-: A Certification Authority or a Registration Authority.
-
-**Certification Authority Software** 
-
-: Key Management and cryptographic software used to manage certificates issued to subscribers.
-
-**Certificate Policy (CP)**
-
-: A Certificate Policy is a specialized form of administrative policy tuned to electronic transactions performed during certificate management.  A Certificate Policy addresses all aspects associated with the generation, production, distribution, accounting, compromise recovery and administration of digital certificates. Indirectly, a certificate policy can also govern the transactions conducted using a communications system protected by a certificate-based security system.  By controlling critical certificate extensions, such policies and associated enforcement technology can support provision of the security services required by particular applications.
-
-**Certification Practice Statement (CPS)**
-
-: A statement of the practices that a CA employs in issuing, suspending, revoking and renewing certificates and providing access to them, in accordance with specific requirements (i.e., requirements specified in this CP, or requirements specified in a contract for services).
-
-**Certificate-Related Information**
-
-: Information, such as a subscriber's postal address, that is not included in a certificate. May be used by a CA managing certificates.
-Certificate Revocation List (CRL)|A list maintained by a Certification Authority of the certificates which it has issued that are revoked prior to their stated expiration date.
-
-**Certificate Status Authority**
-
-: A trusted entity that provides on-line verification to a Relying Party of a subject certificate's trustworthiness, and may also provide additional attribute information for the subject certificate.
-
-**Client (application)**
-
-: A system entity, usually a computer process acting on behalf of a human user, that makes use of a service provided by a server.
-Common Criteria|A set of internationally accepted semantic tools and constructs for describing the security needs of customers and the security attributes of products.
-
-**Compromise**
-
-: Disclosure of information to unauthorized persons, or a violation of the security policy of a system in which unauthorized intentional or unintentional disclosure, modification, destruction, or loss of an object may have occurred. 
-
-**Computer Security Objects Registry (CSOR)**
-
-: Computer Security Objects Registry operated by the National Institute of Standards and Technology.
-
-**Confidentiality**
-
-: Assurance that information is not disclosed to unauthorized entities or processes. 
-
-**Cross-Certificate**
-
-: A certificate used to establish a trust relationship between two Certification Authorities.
-
-**Cryptographic Module**
-
-: The set of hardware, software, firmware, or some combination thereof that implements cryptographic logic or processes, including cryptographic algorithms, and is contained within the cryptographic boundary of the module.
-
-**Cryptoperiod**
-
-: Time span during which each key setting remains in effect. 
-
-**Custodial Subscriber Key Stores**
-
-: Custodial Subscriber Key Stores hold keys for a number of Subscriber certificates in one location.
-
-## D
-[*Back to top*](#glossary)
-
-**Data Integrity**
-
-: Assurance that the data are unchanged from creation to reception.
-
-**Digital Signature**
-
-: The result of a transformation of a message by means of a cryptographic system using keys such that a Relying Party can determine: (1) whether the transformation was created using the private key that corresponds to the public key in the signer’s digital certificate; and (2) whether the message has been altered since the transformation was made.
-
-**Dual Use Certificate**
-
-: A certificate that is intended for use with both digital signature and data encryption services.
-
-**Duration**
-
-: A field within a certificate which is composed of two subfields; “date of issue” and “date of next issue”. 
-
-## E
-[*Back to top*](#glossary)
-
-**E-commerce**
-
-: The use of network technology (especially the internet) to buy or sell goods and services.
-
-**Encrypted Network**
-
-: A network that is protected from outside access by NSA approved high-grade (Type I) cryptography.  Examples are SIPRNET and TOP SECRET networks.
-
-**Encryption Certificate**
-
-: A certificate containing a public key that is used to encrypt electronic messages, files, documents, or data transmissions, or to establish or exchange a session key for these same purposes.
-
-**End-entity**
-
-: Relying Parties and Subscribers.
-
-**Entity**
-
-: For the purposes of this document, “Entity” refers to an organization, corporation, community of interest, or government agency with operational control of a CA.
-
-**Entity CA**
-
-: A CA that acts on behalf of an Entity, and is under the operational control of an Entity.  The Entity may be an organization, corporation, or community of interest.  For the Federal Government, an Entity may be any department, subordinate element of a department, or independent organizational entity that is statutorily or constitutionally recognized as being part of the Federal Government.
-
-## F
-[*Back to top*](#glossary)
-
-**FBCA Management Authority (FPKIMA)**
-
-: The Federal Public Key Infrastructure Management Authority is the organization selected by the Federal Public Key Infrastructure Policy Authority to be responsible for operating the Federal Bridge Certification Authority.
-
-**Federal Public Key Infrastructure Policy Authority (FPKIPA)** 
-
-: The FPKIPA is a federal government body responsible for setting, implementing, and administering policy decisions regarding inter Entity PKI interoperability that uses the FBCA.
-
-**Firewall** 
-
-: Gateway that limits access between networks in accordance with local security policy. 
-
-## H
-[*Back to top*](#glossary)
-
-**High Assurance Guard (HAG)**
-
-: An enclave boundary protection device that controls access between a local area network that an enterprise system has a requirement to protect, and an external network that is outside the control of the enterprise system, with a high degree of assurance.
-
-## I
-[*Back to top*](#glossary)
-
-**Information System Security Officer (ISSO)**
-
-: Person responsible to the designated approving authority for ensuring the security of an information system throughout its lifecycle, from design through disposal. 
-
-**Inside threat**
-
-: An entity with authorized access that has the potential to harm an information system through destruction, disclosure, modification of data, and/or denial of service.
-
-**Integrity**
-
-: Protection against unauthorized modification or destruction of information. . A state in which information has remained unaltered from the point it was produced by a source, during transmission, storage, and eventual receipt by the destination.
-
-**Intellectual Property**
-
-: Useful artistic, technical, and/or industrial information, knowledge or ideas that convey ownership and control of tangible or virtual usage and/or representation.
-
-**Intermediate CA**
-
-: A CA that is subordinate to another CA, and has a CA subordinate to itself.
-
-## K
-[*Back to top*](#glossary)
-
-**Key Escrow**
-
-: A deposit of the private key of a subscriber and other pertinent information pursuant to an escrow agreement or similar contract binding upon the subscriber, the terms of which require one or more agents to hold the subscriber's private key for the benefit of the subscriber, an employer, or other party, upon provisions set forth in the agreement.
-
-**Key Exchange**
-
-: The process of exchanging public keys in order to establish secure communications.
-
-**Key Generation Material**
-
-: Random numbers, pseudo-random numbers, and cryptographic parameters used in generating cryptographic keys.
-
-**Key Pair**
-
-: Two mathematically related keys having the properties that (1) one key can be used to encrypt a message that can only be decrypted using the other key, and (ii) even knowing one key, it is computationally infeasible to discover the other key.
-
-## L
-[*Back to top*](#glossary)
-
-**Local Registration Authority (LRA)**
-
-: A Registration Authority with responsibility for a local community.
-
-## M
-[*Back to top*](#glossary)
-
-**Memorandum of Agreement (MOA)**
-
-: Agreement between the FPKIPA and an Entity allowing interoperability between the Entity Principal CA and the FBCA.
-
-**Mission Support Information**
-
-: Information that is important to the support of deployed and contingency forces.
-
-**Mutual Authentication**
-
-: Occurs when parties at both ends of a communication activity authenticate each other (see authentication).
-
-## N
-[*Back to top*](#glossary)
-
-**Naming Authority** 
-
-: An organizational entity responsible for assigning distinguished names (DNs) and for assuring that each DN is meaningful and unique within its domain.
-
-**National Security System**
-
-: Any telecommunications or information system operated by the United States Government, the function, operation, or use of which involves intelligence activities; involves cryptologic activities related to national security; involves command and control of military forces; involves equipment that is an integral part of a weapon or weapons system; or is critical to the direct fulfillment of military or intelligence missions, but does not include a system that is to be used for routine administrative and business applications (including payroll, finance, logistics, and personnel management applications).
-
-**Non-Repudiation**
-
-: Assurance that the sender is provided with proof of delivery and that the recipient is provided with proof of the sender's identity so that neither can later deny having processed the data.  Technical non-repudiation refers to the assurance a Relying Party has that if a public key is used to validate a digital signature, that signature had to have been made by the corresponding private signature key.  Legal non-repudiation refers to how well possession or control of the private signature key can be established.
-
-## O
-[*Back to top*](#glossary)
-
-**Object Identifier (OID)**
-
-: A specialized formatted number that is registered with an internationally recognized standards organization.  The unique alphanumeric/numeric identifier registered under the ISO registration standard to reference a specific object or object class.  In the federal government PKI they are used to uniquely identify each of the seven policies and cryptographic algorithms supported.
-
-**Out-of-Band**
-
-: Communication between parties utilizing a means or method that differs from the current method of communication (e.g., one party uses U.S. Postal Service mail to communicate with another party where current communication is occurring online).
-
-**Outside Threat**
-
-: An unauthorized entity from outside the domain perimeter that has the potential to harm an Information System through destruction, disclosure, modification of data, and/or denial of service.
-
-## P
-[*Back to top*](#glossary)
-
-**Physically Isolated Network**
-
-: A network that is not connected to entities or systems outside a physically controlled space.
-
-**PKI Sponsor**
-
-: Fills the role of a Subscriber for non-human system components that are named as public key certificate subjects, and is responsible for meeting the obligations of Subscribers as defined throughout this CP.
-
-**Policy Management Authority (PMA)**
-
-: The individual or group that is responsible for the creation and maintenance of Certificate Policies and Certification Practice Statements, and for ensuring that all Entity PKI components (e.g., CAs, CSSs, CMSs, RAs) are audited and operated in compliance with the entity PKI CP. The PMA evaluates non-domain policies for acceptance within the domain, and generally oversees and manages the PKI certificate policies.  For the FBCA, the PMA is the FPKIPA.
-
-**Principal CA**
-
-: The Principal CA is a CA designated by an Entity to interoperate with the FBCA.  An Entity may designate multiple Principal CAs to interoperate with the FBCA.
-
-**Privacy**
-
-: Restricting access to subscriber or Relying Party information in accordance with Federal law and Entity policy.
-
-**Private Key** 
-
-: (1) The key of a signature key pair used to create a digital signature. (2) The key of an encryption key pair that is used to decrypt confidential information. In both cases, this key must be kept secret.
-
-**Public Key** 
-
-: (1) The key of a signature key pair used to validate a digital signature.  (2) The key of an encryption key pair that is used to encrypt confidential information. In both cases, this key is made publicly available normally in the form of a digital certificate.
-
-**Public Key Infrastructure (PKI)**
-
-## R
-[*Back to top*](#glossary)
-
-: A set of policies, processes, server platforms, software and workstations used for the purpose of administering certificates and public-private key pairs, including the ability to issue, maintain, and revoke public key certificates.
-
-**Registration Authority (RA)**
-
-: An entity that is responsible for identification and authentication of certificate subjects, but that does not sign or issue certificates (i.e., a Registration Authority is delegated certain tasks on behalf of an authorized CA).
-
-**Re-key (a certificate)**
-
-: To change the value of a cryptographic key that is being used in a cryptographic system application; this normally entails issuing a new certificate on the new public key.
-
-**Relying Party**
-
-: A person or Entity who has received information that includes a certificate and a digital signature verifiable with reference to a public key listed in the certificate, and is in a position to rely on them.
-
-**Renew (a certificate)**
-
-: The act or process of extending the validity of the data binding asserted by a public key certificate by issuing a new certificate.
-
-**Repository**
-
-: A database containing information and data relating to certificates as specified in this CP; may also be referred to as a directory.
-
-**Responsible Individual**
-
-: A trustworthy person designated by a sponsoring organization to authenticate individual applicants seeking certificates on the basis of their affiliation with the sponsor.
-
-**Revoke a Certificate**
-
-: To prematurely end the operational period of a certificate effective at a specific date and time.
-
-**Risk**
-
-: An expectation of loss expressed as the probability that a particular threat will exploit a particular vulnerability with a particular harmful result.
-
-**Risk Tolerance**
-
-: The level of risk an entity is willing to assume in order to achieve a potential desired result.
-
-**Root CA**
-
-: In a hierarchical PKI, the CA whose public key serves as the most trusted datum (i.e., the beginning of trust paths) for a security domain.
-
-## S
-[*Back to top*](#glossary)
-
-**Server**
-
-: A system entity that provides a service in response to requests from clients.
-
-**Signature Certificate**
-
-: A public key certificate that contains a public key intended for verifying digital signatures rather than encrypting data or performing any other cryptographic functions.
-
-**Subordinate CA**
-
-: In a hierarchical PKI, a CA whose certificate signature key is certified by another CA, and whose activities are constrained by that other CA. (See superior CA).
-
-**Subscriber**
-
-: A Subscriber is an entity that (1) is the subject named or identified in a certificate issued to that entity, (2) holds a private key that corresponds to the public key listed in the certificate, and (3) does not itself issue certificates to another party.  This includes, but is not limited to, an individual or network device.
-
-**Superior CA**
-
-: In a hierarchical PKI, a CA who has certified the certificate signature key of another CA, and who constrains the activities of that CA. (See subordinate CA).
-
-**System Equipment Configuration**
-
-: A comprehensive accounting of all system hardware and software types and settings.
-
-**System High**
-
-: The highest security level supported by an information system. 
-
-## T
-[*Back to top*](#glossary)
-
-**Technical non-repudiation**
-
-: The contribution public key mechanisms to the provision of technical evidence supporting a non-repudiation security service.
-
-**Threat**
-
-: Any circumstance or event with the potential to cause harm to an information system in the form of destruction, disclosure, adverse modification of data, and/or denial of service. 
-
-**Trust List**
-
-: Collection of trusted certificates used by Relying Parties to authenticate other certificates.
-
-**Trusted Agent**
-
-: Entity authorized to act as a representative of an Entity in confirming Subscriber identification during the registration process.  Trusted Agents do not have automated interfaces with Certification Authorities.
-
-**Trusted Certificate**
-
-: A certificate that is trusted by the Relying Party on the basis of secure and authenticated delivery.  The public keys included in trusted certificates are used to start certification paths.  Also known as a "trust anchor".
-
-**Trusted Timestamp**
-
-: A digitally signed assertion by a trusted authority that a specific digital object existed at a particular time.
-
-**Trustworthy System**
-
-: Computer hardware, software and procedures that: (1) are reasonably secure from intrusion and misuse; (2) provide a reasonable level of availability, reliability, and correct operation; (3) are reasonably suited to performing their intended functions; and (4) adhere to generally accepted security procedures.
-
-**Two-Person Control**
-
-: Continuous surveillance and control of positive control material at all times by a minimum of two authorized individuals, each capable of detecting incorrect and/or unauthorized procedures with respect to the task being performed and each familiar with established security and safety requirements. 
-
-## U
-[*Back to top*](#glossary)
-
-**Update (a certificate)**
-
-: The act or process by which data items bound in an existing public key certificate, especially authorizations granted to the subject, are changed by issuing a new certificate.
-
-## Z
-[*Back to top*](#glossary)
-
-**Zeroize**
-
-: A method of erasing electronically stored data by altering the contents of the data storage so as to prevent the recovery of the data. 
+The FPKI community uses a lot of terms and acronyms, some of which you may not be familiar with.  Below are links to authoritative sources that explain or describe these terms in greater detail. 
+
+This list is in-progress and will be updated and refined in the future.  Please feel free to add terms or give suggestions for how it can be improved here - [How to Contribute](/pages/contribute.md){:target="_blank"}
+
+Link|Description|Publication/Revision Date
+---|---|---
+[NISTIR 7298 Glossary of Key Information Security Terms](http://dx.doi.org/10.6028/NIST.IR.7298r2)|Comprehensive definitions from FIPS, NIST SP 800 and NISTIR docs, & CNSSI 4009 with citations for each definition.|May 2013
+[National Initiative for Cybersecurity Careers and Studies Glossary](https://niccs.us-cert.gov/glossary)|Complements NISTIR 7298 for understanding common terms.  Use plain language and annotations to make definitions simipler to understand.| March 31, 2017
+[CNSSI 4009 Committee on National Security Standards (CNSS) Glossary](https://www.cnss.gov/CNSS/openDoc.cfm?Cbbcv/b/+whX6cEC2qFsSw==)|Definitions sourced and cited from authoritative documents where possible.  Resolves differences between DoD, Intelligence Community, and NIST to establish consistent definition of terms.|April 6, 2015
+[FICAM Roadmap and Implementation Guidance - Appendix B: Glossary](https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TNNBAA4&field=File__Body__s)| Terms and definitions specific to the Federal Identity, Credential, and Access Management program.|December 2, 2011
+[NIST SP 800-63-3 Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63-3.html#sec3)|Terms specific to digital identity, many are not included in other glossaries.|*In Progress*
+[NIST SP 800-63A Enrollment and Identity Proofing](https://pages.nist.gov/800-63-3/sp800-63a.html#sec3)|Terms specific to digital identity, many are not included in other glossaries.|*In Progress*
+[NIST SP 800-63B Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63b.html#sec3)|Terms specific to authentication and digital identity, many are not included in other glossaries.|*In Progress*
+[NIST SP 800-63C Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63c.html#sec3)|Terms specific to authentication and digital identity, many are not included in other glossaries.|*In Progress*
+
+---
+
+* [NISTIR 7298 Glossary of Key Information Security Terms](http://dx.doi.org/10.6028/NIST.IR.7298r2)
+  * Comprehensive definitions from FIPS, NIST SP 800 and NISTIR docs, & CNSSI 4009 with citations for each definition.
+  * Last updated May 2013
+  
+* [National Initiative for Cybersecurity Careers and Studies Glossary](https://niccs.us-cert.gov/glossary)
+  * Complements NISTIR 7298 for understanding common terms.  Use plain language and annotations to make definitions simipler to understand.
+  * Last updated March 31, 2017
+  
+* [CNSSI 4009 Committee on National Security Standards (CNSS) Glossary](https://www.cnss.gov/CNSS/openDoc.cfm?Cbbcv/b/+whX6cEC2qFsSw==)
+  * Definitions sourced and cited from authoritative documents where possible.  Resolves differences between DoD, Intelligence Community, and NIST to establish consistent definition of terms.
+  * Last updated April 6, 2015
+  
+* [FICAM Roadmap and Implementation Guidance](https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TNNBAA4&field=File__Body__s)
+  * Terms and definitions specific to the Federal Identity, Credential, and Access Management program.
+  * Last updated December 2, 2011
+  
+* [NIST SP 800-63-3 Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63-3.html#sec3)
+  * Terms specific to digital identity, many are not included in other glossaries.
+  * Draft document, still in progress.
+  
+* [NIST SP 800-63A Enrollment and Identity Proofing](https://pages.nist.gov/800-63-3/sp800-63a.html#sec3)
+  * Terms specific to digital identity, many are not included in other glossaries.
+  * Draft document, still in progress.
+  
+* [NIST SP 800-63B Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63b.html#sec3)
+  * Terms specific to authentication and digital identity, many are not included in other glossaries.
+  * Draft document, still in progress.
+  
+* [NIST SP 800-63C Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63c.html#sec3)
+  * Terms specific to authentication and digital identity, many are not included in other glossaries.
+  * Draft document, still in progress.
+  
+---
+
+[NISTIR 7298 Glossary of Key Information Security Terms](http://dx.doi.org/10.6028/NIST.IR.7298r2) -  Comprehensive definitions from FIPS, NIST SP 800 and NISTIR docs, & CNSSI 4009 with citations for each definition.  (Last updated May 2013)
+
+[National Initiative for Cybersecurity Careers and Studies Glossary](https://niccs.us-cert.gov/glossary) - Complements NISTIR 7298 for understanding common terms.  Use plain language and annotations to make definitions simipler to understand.  (Last updated March 31, 2017)
+
+[CNSSI 4009 Committee on National Security Standards (CNSS) Glossary](https://www.cnss.gov/CNSS/openDoc.cfm?Cbbcv/b/+whX6cEC2qFsSw==) - Definitions sourced and cited from authoritative documents where possible.  Resolves differences between DoD, Intelligence Community, and NIST to establish consistent definition of terms.  (Last updated April 6, 2015)
+
+[FICAM Roadmap and Implementation Guidance](https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TNNBAA4&field=File__Body__s) - Terms and definitions specific to the Federal Identity, Credential, and Access Management program.  (Last updated December 2, 2011)
+
+[NIST SP 800-63-3 Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63-3.html#sec3) - Terms specific to digital identity, many are not included in other glossaries.  (Draft document, still in progress.)
+
+[NIST SP 800-63A Enrollment and Identity Proofing](https://pages.nist.gov/800-63-3/sp800-63a.html#sec3) - Terms specific to digital identity, many are not included in other glossaries.  (Draft document, still in progress.)
+
+[NIST SP 800-63B Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63b.html#sec3) - Terms specific to authentication and digital identity, many are not included in other glossaries.  (Draft document, still in progress)
+
+[NIST SP 800-63C Authentication & Lifecycle Management](https://pages.nist.gov/800-63-3/sp800-63c.html#sec3) - Terms specific to authentication and digital identity, many are not included in other glossaries.  (Draft document, still in progress)


### PR DESCRIPTION
Updated the glossary page to link to existing glossaries rather than re-creating them.  The glossary is duplicated to present different formatting options: table, bulleted list, and in-line.

Would also add ICAM Lexicon to the list, but searching for the doc leads to a 404 error on the new IDManagement page.  Not sure if the doc was retired or the link will be fixed later.

@lachellel @djpackham let me know which format you prefer and if there are any other changes you want made.