### PR TITLE
Update Microsoft Friendly Name of FCPCA

### DIFF
--- a/pages/fpki_truststores.md
+++ b/pages/fpki_truststores.md
@@ -37,6 +37,8 @@ Opera|No longer operates its own program and relies upon Mozilla.
 
 {% include alert-info.html content="Google Chrome uses the underlying trust library of the operating system on Windows or Apple OS X systems. Linux-based systems distribute the Mozilla NSS Library which may be modified by each version of Linux." %}
 
+{% include alert-info.html content="In Microsoft, the Federal Common Policy CA is called, "U.S. Government Common Policy." %}
+
 ### How do I set dynamic path validation for the trust store in Windows operating systems?
 
 With dynamic path validation (as opposed to static path validation), the certificate validation software will build the certificate chain based on the Authority Information Access (AIA) entry in the certificate.  


### PR DESCRIPTION
I added a note that FCPCA is called "U.S. Government Common Policy" in Microsoft to address issue #126 