### PR TITLE
option for consolidating

### DIFF
--- a/_announcements/01_apple_common_removal.md
+++ b/_announcements/01_apple_common_removal.md
@@ -47,7 +47,7 @@ These Apple Operating System versions will be impacted:
 | High Sierra (10.13) |	 iOS11 | tvOS11 |
 
 
-Government users will receive errors on government - Apple devices if any of these are true:
+Government users will receive errors on government-furnished Apple devices if any of these are true:
 
 1. Logging into a government network with a PIV credential 
 2. Authenticating to a government Virtual Private Network (VPN) endpoint with a PIV credential
@@ -64,7 +64,7 @@ You can mitigate the risk to government missions, intranets, applications, and g
 
 ## What Should I Do?
 
-You will need to download the COMMON root CA certificate **and** install the root certificate on government furnished Apple devices.  Installations should use enterprise configuration management tools, and these steps should only be completed by the agency enterprise administrators or network engineers.  
+You will need to download the COMMON root CA certificate **and** install the root certificate on government-furnished Apple devices.  Installations should use enterprise configuration management tools, and these steps should only be completed by the agency enterprise administrators or network engineers.  
 
 * [Download Options](#download-options)
 * [Install Options](#install-options)
@@ -134,7 +134,7 @@ You can install COMMON in your agency enterprise Apple devices Trust Stores usin
 * [Option 4. Install Using Safari Web Browser](#option-4-install-using-safari-web-browser)
 
 
-#### Option 1:&nbsp;&nbsp;Install Using an Apple Configuration Profile
+#### Option 1. Install Using an Apple Configuration Profile
 This option works for both MacOS and iOS devices.
 
 Apple Configuration Profiles (XML files) can be used to distribute trusted root certificates to your agency's enterprise Apple devices.  Create a Configuration Profile by using Apple's Configurator 2 application. An example configuration profile is included beneath the configuration creation instructions:
@@ -231,7 +231,7 @@ The configuration profile can be distributed:
 5. [Over-the-air using a Mobile Device Management server](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/6-MDM_Best_Practices/MDM_Best_Practices.html#//apple_ref/doc/uid/TP40017387-CH5-SW2){:target="_blank"} 
 
 
-#### Option 2:&nbsp;&nbsp;Install Using Command Line
+#### Option 2. Install Using Command Line
 This option is for MacOS devices only. 
 1. Install the COMMON root CA certificate as a Trusted Root:
 
@@ -239,7 +239,7 @@ This option is for MacOS devices only.
 	$ sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" {DOWNLOAD_LOCATION}/fcpca.crt
     ```
 
-#### Option 3:&nbsp;&nbsp;Install Using Apple Keychain
+#### Option 3. Install Using Apple Keychain
 This option is for MacOS devices only. 
 
 1. Browse to your downloaded copy of the COMMON root CA certificate.
@@ -249,7 +249,7 @@ This option is for MacOS devices only.
 Non-administrative users may follow the steps above to install COMMON in the Login Keychain specific to their account. This will not impact other user accounts on a device. 
 
 
-#### Option 4:&nbsp;&nbsp;Install Using Safari Web Browser
+#### Option 4. Install Using Safari Web Browser
 This option is for iOS devices only. 
 
 1. Launch Safari.

--- a/_announcements/01_apple_common_removal.md
+++ b/_announcements/01_apple_common_removal.md
@@ -5,16 +5,16 @@ title: Federal Common Policy CA Removal from Apple Trust Stores Impact
 pubDate: June 8, 2018
 collection: announcements
 permalink: announcements/applepkichanges/
-description: Upcoming changes regarding Apple's Root Certificate Program could impact your agency. The Federal PKI Policy Authority has elected to remove our U.S. Government Root CA certificate (Federal Common Policy CA) from the Apple Operating System Trust Stores.  This change will impact government users of Apple iOS, macOS, and tvOS, starting in **September-October 2018**. <br><br> This change will cause government users to receive errors when encountering instances of a Federal PKI CA-issued certificate. You can mitigate the impact for government intranets and government-furnished equipment by using configuration management tools for federal devices.
+description: Upcoming changes regarding Apple devices and operating systems could impact your agency. The Federal PKI Policy Authority has elected to remove our U.S. Government Root CA certificate (Federal Common Policy CA) from the Apple Operating System Trust Stores.  This change will impact government users of Apple iOS, macOS, and tvOS, starting in **September-October 2018**. <br><br> This change will cause government users to receive errors when encountering instances of a Federal PKI CA-issued certificate. You can mitigate the impact for government intranets and government-furnished equipment.
 ---
 
-Upcoming changes regarding Apple's Root Certificate Program could impact your agency. The Federal PKI Policy Authority (FPKIPA) has elected to remove our U.S. Government Root CA certificate (Federal Common Policy CA [FCPCA/COMMON]) from Apple's pre-installed Operating System Trust Stores. 
+Upcoming changes regarding Apple devices and operating systems could impact your agency. The Federal PKI Policy Authority has elected to remove our U.S. Government Root CA certificate (Federal Common Policy CA [COMMON]) from Apple's pre-installed Operating System Trust Stores. 
 
 {% include alert-info.html content="This announcement will be updated as more information and additional procedures become available. Please watch for additional updates from the Federal PKI listservs, ICAM listservs, and the ICAM Subcommittee." %}
 
-Starting in **September-October 2018**, government users of Apple iOS, macOS, and tvOS devices will receive errors when encountering instances of a Federal PKI CA-issued certificate. You can mitigate the impact for government intranets and government-furnished equipment by using configuration management tools for federal devices.
+Starting in **September-October 2018**, government users of Apple iOS, macOS, and tvOS devices will receive errors when encountering instances of a Federal PKI CA-issued certificate. You can mitigate the impact for government intranets and the government-furnished Apple devices.
 
-{% include alert-info.html content="The FPKIPA has also elected to remove the Federal Common Policy CA root certificate from Microsoft's Certificate Trust List." %}
+{% include alert-info.html content="The FPKIPA has also elected to remove the Federal Common Policy CA root certificate from Microsoft's Trust Store." %}
 
 - [How Does this Work?](#how-does-this-work)
 - [What Will Be Impacted?](#what-will-be-impacted)
@@ -24,12 +24,12 @@ Starting in **September-October 2018**, government users of Apple iOS, macOS, an
 
 ## How Does This Work?
 
-Apple currently distributes the Federal Common Policy CA (FCPCA/COMMON) through its pre-installed Operating System Trust Stores for iOS, macOS, and tvOS. 
+Apple currently distributes the Federal Common Policy CA (COMMON) through its pre-installed operating system Trust Stores for iOS, macOS, and tvOS. 
 
 Three root CA certificate _types_ reside in Apple's Trust Stores:
 
 - _Trusted Certificates_ &mdash; Trusted certificates that establish a chain of trust.
-- _Always Ask_ &mdash; Untrusted certificates that are not blocked. If a resource (e.g., website or signed email) chains to one of these certificates, the Apple Operating System will ask you to choose whether or not to trust it.
+- _Always Ask_ &mdash; Untrusted certificates that are not blocked. If a resource (e.g., website or signed email) chains to one of these certificates, the Apple operating system will ask you to choose whether or not to trust it.
 - _Blocked_ &mdash; Potentially compromised certificates that will never be trusted.
 
 These certificate types are stored within Apple _Keychains_:
@@ -40,7 +40,7 @@ These certificate types are stored within Apple _Keychains_:
  
 ## What Will Be Impacted?
 
-These Apple Operating System versions will be impacted:
+These Apple operating system versions will be impacted:
 
 |**macOS**|**iOS**|**tvOS**|
 | :-------- |:-------- |:-------- |
@@ -64,7 +64,7 @@ You can mitigate the risk to government missions, intranets, applications, and g
 
 ## What Should I Do?
 
-You will need to download the COMMON root CA certificate **and** install the root certificate on government-furnished Apple devices.  Installations should use enterprise configuration management tools, and these steps should only be completed by the agency enterprise administrators or network engineers.  
+You will need to download the COMMON root CA certificate **and** install the root certificate on government-furnished Apple devices.  Installations should use enterprise configuration management tools.  These steps should only be completed by the agency enterprise administrators or network engineers.  
 
 * [Download Options](#download-options)
 * [Install Options](#install-options)
@@ -122,11 +122,11 @@ You will need to download the COMMON root CA certificate and install it on gover
 
 #### Option 3. Email Us
 
-To request an out-of-band copy of the COMMON root CA certificate, email us at fpki@gsa.gov.
+Email us at fpki@gsa.gov to request an out-of-band copy of the COMMON root CA certificate.
 
 ### Installation Options
 
-You can install COMMON in your agency enterprise Apple devices Trust Stores using these options: 
+Install COMMON in your agency government-furnished Apple devices using these options: 
 
 * [Option 1. Install Using an Apple Configuration Profile](#option-1-install-using-an-apple-configuration-profile)
 * [Option 2. Install Using Command Line](#option-2-install-using-command-line)
@@ -233,7 +233,8 @@ The configuration profile can be distributed:
 
 #### Option 2. Install Using Command Line
 This option is for MacOS devices only. 
-1. Install the COMMON root CA certificate as a Trusted Root:
+
+1. Command line:
 
     ```
 	$ sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" {DOWNLOAD_LOCATION}/fcpca.crt

--- a/_announcements/01_apple_common_removal.md
+++ b/_announcements/01_apple_common_removal.md
@@ -47,7 +47,7 @@ These Apple Operating System versions will be impacted:
 | High Sierra (10.13) |	 iOS11 | tvOS11 |
 
 
-Government users will receive errors on government-furnished equipment if any of these are true:
+Government users will receive errors on government - Apple devices if any of these are true:
 
 1. Logging into a government network with a PIV credential 
 2. Authenticating to a government Virtual Private Network (VPN) endpoint with a PIV credential
@@ -64,17 +64,12 @@ You can mitigate the risk to government missions, intranets, applications, and g
 
 ## What Should I Do?
 
-These procedures are intended for Enterprise Administrators and/or Network Engineers.
+You will need to download the COMMON root CA certificate **and** install the root certificate on government furnished Apple devices.  Installations should use enterprise configuration management tools, and these steps should only be completed by the agency enterprise administrators or network engineers.  
 
-### macOS&nbsp;&mdash;&nbsp;Download COMMON Options
+* [Download Options](#download-options)
+* [Install Options](#install-options)
 
-You will need to download the COMMON root CA certificate and install it on government-furnished Apple devices by using one of these options:
-
-* [Option 1. Download COMMON Using a Web Browser](#option-1-download-common-using-a-web-browser)
-* [Option 2. Download COMMON Using Terminal](#option-2-download-common-using-terminal)
-* [Option 3. Email Us](#option-3-email-us)
-
-When downloading the COMMON root CA certificate by using the options below, you'll need to verify that it contains these details:
+When downloading the COMMON root CA certificate, you'll need to verify that the certificate contains these details:
 
 | **Federal Common Policy CA (FCPCA/COMMON)**  | **Certificate Details**                             |
 | :--------  | :-------------------------------     |
@@ -85,12 +80,21 @@ When downloading the COMMON root CA certificate by using the options below, you'
 
 {% include alert-warning.html content="You should never install a root certificate without verifying it." %} 
 
+
+### Download Options
+You will need to download the COMMON root CA certificate and install it on government-furnished Apple devices using one of these options:
+
+* [Option 1. Download Using a Web Browser](#option-1-download-using-a-web-browser)
+* [Option 2. Download Using Terminal](#option-2-download-using-terminal)
+* [Option 3. Email Us](#option-3-email-us)
+
+
 **Note:**&nbsp;&nbsp;For all options, replace _{DOWNLOAD_LOCATION}_ with your preferred file download location (e.g., `/Users/Sam.Jackson/Downloads`).
 
-#### Option 1. Download COMMON Using a Web Browser
+#### Option 1. Download Using a Web Browser
 
 1. Open your web browser.
-2. Navigate to the [COMMON root CA certificate](http://http.fpki.gov/fcpca/fcpca.crt){:target="_blank"}.
+2. Navigate to the COMMON root CA certificate located at this URL:  http://http.fpki.gov/fcpca/fcpca.crt
 3. When prompted, save the certificate file to your download location.
 4. Click the *Spotlight* icon and search for _terminal_. 
 5. Double-click the Terminal icon (black monitor icon with white ">_") to open a window.
@@ -99,8 +103,8 @@ When downloading the COMMON root CA certificate by using the options below, you'
     ```
 	$ shasum -a 256 {DOWNLOAD_LOCATION}/fcpca.crt
     ```
-
-#### Option 2. Download COMMON Using Terminal
+    
+#### Option 2. Download Using Terminal
 
 1. Click the *Spotlight* icon and search for _terminal_.
 2. Double-click the Terminal icon (black monitor icon with white ">_") to open a window.
@@ -118,45 +122,32 @@ When downloading the COMMON root CA certificate by using the options below, you'
 
 #### Option 3. Email Us
 
-To request an out-of-band copy of the COMMON root CA certificate to download, email us at fpki@gsa.gov.
+To request an out-of-band copy of the COMMON root CA certificate, email us at fpki@gsa.gov.
 
-### macOS&nbsp;&mdash;&nbsp;Install COMMON Options
+### Installation Options
 
-You can install COMMON in your macOS device's Trust Store by using one of these options: 
+You can install COMMON in your agency enterprise Apple devices Trust Stores using these options: 
 
-* [Option 1. Install COMMON Using an Apple Configuration Profile](#option-install-common-using-an-apple-configuration-profile)
-* [Option 2. Install COMMON Using Command Line](#option-2-install-common-using-command-line)
-* [Option 3. Install COMMON Using Apple Keychain](#option-3-install-common-using-apple-keychain)
+* [Option 1. Install Using an Apple Configuration Profile](#option-1-install-using-an-apple-configuration-profile)
+* [Option 2. Install Using Command Line](#option-2-install-using-command-line)
+* [Option 3. Install Using Apple Keychain](#option-3-install-using-apple-keychain)
+* [Option 4. Install Using Safari Web Browser](#option-4-install-using-safari-web-browser)
 
-#### Option 1. Install COMMON Using an Apple Configuration Profile
 
-These procedures are intended for Enterprise Administrators. 
+#### Option 1:&nbsp;&nbsp;Install Using an Apple Configuration Profile
+This option works for both MacOS and iOS devices.
 
-You can create Apple Configuration Profiles (XML files) to distribute trusted root certificates across an Enterprise's Apple devices. An example "Ready-To-Use" Apple Configuration Profile to install COMMON is presented beneath the configuration creation instructions.
-
-* [Create Configuration Profiles to Install COMMON for macOS, iOS, and tvOS](#create-configuration-profiles-to-install-common-for-macOS- iOS-and-tvOS)
-* [Ready-To-Use Configuration Profile To Install COMMON](#ready-to-use-configuration-profile-to-install-common)
-* [Distribute Configuration Profiles To Install COMMON](#distribute-configuration-profiles-to-install-common)
-
-##### Create Configuration Profiles to Install COMMON for macOS, iOS, and tvOS
-
-One way you can create a Configuration Profile is by using Apple's free Configurator 2 application:
+Apple Configuration Profiles (XML files) can be used to distribute trusted root certificates to your agency's enterprise Apple devices.  Create a Configuration Profile by using Apple's Configurator 2 application. An example configuration profile is included beneath the configuration creation instructions:
 
 1. Download and install Configurator 2 from the Apple App Store.
 2. Open Configurator and click *File* -> *New Profile*.
-3. Under *General*, enter a unique profile *Name*. ("Federal Common Policy Certification Authority Profile" was used for the below example.)
-4. Enter a unique profile *Identifier*. ("FCPCA-0001" was used for the below example.)
-5. Browse to local *certificate* copies on your device. Select those that you'd like to add to the profile. (For the below example, a copy of the Federal Common Policy CA root certificate was used.)
+3. Under *General*, enter a unique profile *Name*. ("Federal Common Policy Certification Authority Profile" was used for this example.)
+4. Enter a unique profile *Identifier*. ("FCPCA-0001" was used for this example.)
+5. Browse to local *certificate* copies on your device. Select those that you'd like to add to the profile. (For this example, a copy of the Federal Common Policy CA root certificate was used.)
 6. Click *File* -> *Save* to save your profile to a preferred file location.
-7. Close Configurator 2.
 
-##### Ready-To-Use Configuration Profile To Install COMMON
+This example configuration profile will install COMMON as a trusted root CA for _both macOS and iOS_ devices. Before using the profile, you should verify its suitability for your agency. To use the profile, copy the XML information and save it to a file with a `.mobileconfig` extension. 
 
-The example configuration profile below (created with Configurator 2) will install COMMON as a trusted root CA for _both macOS and iOS_. Before using the profile, you should verify its suitability for your agency. 
-
-To repurpose the profile, save it with a `.mobileconfig` extension. 
-
-For more information, see: [Apple Configuration Profile Reference](https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html){:target="_blank"}
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>
@@ -229,40 +220,40 @@ For more information, see: [Apple Configuration Profile Reference](https://devel
 </dict>
 </plist>
 ``` 
-##### Distribute Apple Configuration Profiles To Install COMMON
 
-Use any of these options to distribute your configuration profiles: 
+##### Distribute Configuration Profiles 
+The configuration profile can be distributed: 
 
-1. Via Apple's free _Configurator 2_ application with devices connected via USB 
-2. In an email message 
-3. On a webpage 
+1. Using Apple's _Configurator 2_ application with devices connected via USB 
+2. In an email message to select agency users.  Email messages should never be used outside your agency domain.
+3. On an agency intranet webpage 
 4. [Over-the-air profile delivery and configuration](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/Introduction/Introduction.html#//apple_ref/doc/uid/TP40009505){:target="_blank"}
 5. [Over-the-air using a Mobile Device Management server](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/6-MDM_Best_Practices/MDM_Best_Practices.html#//apple_ref/doc/uid/TP40017387-CH5-SW2){:target="_blank"} 
 
-#### Option 2. Install COMMON Using Command Line
+
+#### Option 2:&nbsp;&nbsp;Install Using Command Line
+This option is for MacOS devices only. 
 1. Install the COMMON root CA certificate as a Trusted Root:
 
     ```
 	$ sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" {DOWNLOAD_LOCATION}/fcpca.crt
     ```
 
-#### Option 3. Install COMMON Using Apple Keychain
+#### Option 3:&nbsp;&nbsp;Install Using Apple Keychain
+This option is for MacOS devices only. 
+
 1. Browse to your downloaded copy of the COMMON root CA certificate.
 2. Double-click on the file.
 3. When prompted, enter your password to install the certificate.
 
-Non-administrative users may follow the steps above to install COMMON in the Login Keychain, which is specific to their accounts. This will not impact other user accounts on a device. 
+Non-administrative users may follow the steps above to install COMMON in the Login Keychain specific to their account. This will not impact other user accounts on a device. 
 
-### iOS&nbsp;&mdash;&nbsp;Install COMMON Options
 
-You can install COMMON in your iOS device's Trust Store by using one of these options:
+#### Option 4:&nbsp;&nbsp;Install Using Safari Web Browser
+This option is for iOS devices only. 
 
-* [Option 1. Install COMMON Using Safari Web Browser](#option-1-install-common-using-safari-web-browser)
-* [Option 2. Install COMMON Using Apple Configuration Profile](#option-2-install-common-using-apple-configuration-profile)
-
-#### Option 1. Install COMMON Using Safari Web Browser
-1. Open Safari.
-2. Navigate to the [COMMON root CA certificate](http://http.fpki.gov/fcpca/fcpca.crt){:target="_blank"}<br>
+1. Launch Safari.
+2. Navigate to the COMMON root CA certificate located at this URL: http://http.fpki.gov/fcpca/fcpca.crt<br>
 > System message appears: *The website is trying to open Settings to show you a configuration profile. Do you want to allow this?*<br>
 3. Click *Allow*.<br>
 > The COMMON Configuration Profile appears.<br> 
@@ -279,14 +270,6 @@ Next, you'll need to enable full trust for COMMON:
 2. Beneath *Enable Full Trust for Root Certificates*, toggle _ON_ for the Federal Common Policy CA entry. 
 3. When certificate appears, click *Continue*.
 4. You can now successfully navigate to an intranet site whose TLS certificate was issued by a Federal PKI CA.
-
-
-#### Option 2. Install COMMON Using Apple Configuration Profile
-You can use the macOS configuration profile procedures above to install COMMON on iOS devices: [Apple Configuration Profiles](#install-using-an-apple-configuration-profile).
-
-
-### tvOS&nbsp;&mdash;&nbsp;Install COMMON Options
-If you would like to install COMMON on tvOS government-furnished equipment, email us at fpki@gsa.gov.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Changes included consolidating the download and install options together (for both MacOS and iOS), adding in more sub-links, and removing "COMMON" from all the sub-section headers.