### PR TITLE
Remove Chrome browser from the list of platforms serviced by Google's root program

### DIFF
--- a/_truststores/00_index.md
+++ b/_truststores/00_index.md
@@ -32,7 +32,7 @@ Apple Root Certificate Program|Yes (pending removal)|Keychain Access Utility|mac
 Mozilla Network Security Services (NSS)|No |Browser trust store|Firefox, Thunderbird, Linux Operating Systems|https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/
 Adobe Approved Trust List|Yes|Application trust store|Adobe Acrobat|https://helpx.adobe.com/acrobat/kb/approved-trust-list2.html
 Java Root Certificate Program|No|Java Applet|Java Distributions|http://www.oracle.com/technetwork/java/javase/javasecarootcertsprogram-1876540.html
-Google|No|Google Admin Console|Chrome Browser, Android OS, Chromium OS|https://www.chromium.org/Home/chromium-security/root-ca-policy
+Google|No|Google Admin Console|Android OS, Chromium OS|https://www.chromium.org/Home/chromium-security/root-ca-policy
 Opera|No longer operates its own program and relies on Mozilla
 
 {% include alert-info.html content="Google Chrome uses the trust store of the operating system on Microsoft, Apple, and Android systems. Linux-based systems distribute the Mozilla NSS Library, which may be modified by each version of Linux." %}


### PR DESCRIPTION
As is noted in the alert box below the table, Chrome uses the platform's trust store (it adds additional restrictions above and beyond that, however).