### PR TITLE
Federal PKI Activity Update - Jan 2019

### DIFF
--- a/_includes/fpkiar-repo-table.html
+++ b/_includes/fpkiar-repo-table.html
@@ -21,7 +21,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <th class="tg-llyw">Federal Agency or Affiliate CA</th>
         <td class="tg-llyw">FPKIMA CA</td>
-        <td class="tg-llyw">Nov 2018</td>
+        <td class="tg-llyw">Dec 2018</td>
         <td class="tg-llyw">Average</td>
     </tr>
     <tr>
@@ -45,7 +45,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">DoD Interoperability Root CA 2</td>
         <td class="tg-y698">FBCA</td>
-        <td class="tg-s7ni">99.05</td>
+        <td class="tg-s7ni">100</td>
         <td class="tg-s7ni">99.92</td>
     </tr>
     <tr>
@@ -129,7 +129,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">Symantec Class 3 SSP Intermediate CA - G3</td>
         <td class="tg-y698">FBCA</td>
-        <td class="tg-s7ni">98.45</td>
+        <td class="tg-s7ni">100</td>
         <td class="tg-s7ni">99.87</td>
     </tr>
     <tr>
@@ -171,7 +171,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-0pky">Symantec SSP Intermediate CA - G4</td>
         <td class="tg-0pky">FCPCA</td>
-        <td class="tg-s7ni">96.51</td>
+        <td class="tg-s7ni">100</td>
         <td class="tg-s7ni">99.67</td>
     </tr>
     <tr>
@@ -189,7 +189,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">Verisign SSP Intermediate CA - G3</td>
         <td class="tg-y698">FCPCA</td>
-        <td class="tg-s7ni">96.48</td>
+        <td class="tg-s7ni">100</td>
         <td class="tg-s7ni">99.71</td>
     </tr>
     <tr>
@@ -207,7 +207,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-0pky">DoD Interoperability Root CA 1</td>
         <td class="tg-0pky">SHA1FRCA</td>
-        <td class="tg-s7ni">99.14</td>
+        <td class="tg-s7ni">100</td>
         <td class="tg-s7ni">99.93</td>
     </tr>
     <tr>

--- a/_includes/fpkiar-repo-table.html
+++ b/_includes/fpkiar-repo-table.html
@@ -45,7 +45,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">DoD Interoperability Root CA 2</td>
         <td class="tg-y698">FBCA</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.92</td>
     </tr>
     <tr>
@@ -129,7 +129,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">Symantec Class 3 SSP Intermediate CA - G3</td>
         <td class="tg-y698">FBCA</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.87</td>
     </tr>
     <tr>
@@ -171,7 +171,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-0pky">Symantec SSP Intermediate CA - G4</td>
         <td class="tg-0pky">FCPCA</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.67</td>
     </tr>
     <tr>
@@ -189,7 +189,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">Verisign SSP Intermediate CA - G3</td>
         <td class="tg-y698">FCPCA</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.71</td>
     </tr>
     <tr>
@@ -207,7 +207,7 @@ No Issues - Green - d52n (USDS-#FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-0pky">DoD Interoperability Root CA 1</td>
         <td class="tg-0pky">SHA1FRCA</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.93</td>
     </tr>
     <tr>

--- a/_tools/03_fpki_activity_report.md
+++ b/_tools/03_fpki_activity_report.md
@@ -5,7 +5,7 @@ collection: tools
 permalink: tools/fpkiactivityreport/
 ---
 
-Updated: December 1, 2018
+Updated: January 1, 2019
 
 This report provides a technical and policy compliance status for each Federal Public Key Infrastructure (FPKI) Affiliate.
 
@@ -45,6 +45,7 @@ The following certificates are expiring in the next four months and may be re-is
 | --------- | ---------- | ---------- | ------ | ---------- |
 | STRAC Bridge | Federal Bridge CA 2016 | STRAC Bridge Root CA | 05B522AD82D4E1781BAB378E838AF4FFBAE0D7C9 | 02/21/2019 |
 | STRAC Bridge | STRAC Bridge Root CA | Federal Bridge CA 2016 | E4F6FBD50205A9645037FEF31EFCC83B78F9D68D | 02/21/2019 |
+| CertiPath Bridge | Federal Bridge CA 2016 | CertiPath Bridge CA - G2 | 6305CFA15E6E6AD972847251B6930FEA8D6087DB | 04/30/2019 |
 
 ## Repository Availability 
 Respository availability is an uptime metric for Certificate Revocation List availability. The table only contains Certification Authorities directly certified with the FPKIMA. A metric of "99" in the table below means the Certificate Revocation List was available for 99% of the given month, in other words, the file was not available for 1% of the month (18 minutes depending on the month). The last column is the 12-Month average.


### PR DESCRIPTION
FPKIAR Updates for Jan 2019

- Added CertiPath Bridge - G2 will expire in next fourth months.
- Updated Repo Table.