### PR TITLE
System notice 2212019

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -601,12 +601,27 @@
   aia_uri: http://http.fpki.gov/bridge/caCertsIssuedTofbca2016.p7c
   sia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
   
- - notice_date: February 20, 2019
- change_type: Intent to Perform CA Certificate Issuance
- start_datetime: Issuance date to be determined
- system: CertiPath Bridge CA G2
- change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location: http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c
- contact: judith dot spencer at certipath dot com
+- notice_date: February 20, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime: Issuance date to be determined
+  system: CertiPath Bridge CA G2
+  change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location: http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c
+  contact: judith dot spencer at certipath dot com
+  
+- notice_date: February 21, 2019
+  change_type: CA Certificate Issuance
+  start_datetime: February 20, 2019
+  end_datetime: February 19, 2022
+  system: STRAC Bridge Root Certification Authority
+  change_description: New cross-certificate issued from STRAC Bridge Root Certification Authority to Federal Bridge 2016
+  contact: pki at strac dot org
+  ca_certificate_hash: EE02BDB684AB4714C5F25300C41C5B8F328B0CD9
+  ca_certificate_issuer: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
+  ca_certificate_subject: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
+  cdp_uri: http://pki.strac.org/bridge/crl/STRACBridgeRootCA.crl
+  aia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
+  sia_uri: http://http.fpki.gov/bridge/caCertsIssuedByfbca2016.p7c
+  ocsp_uri: http://certstatus.strac.org
 
 #- notice_date: 
 #  change_type: CA Certificate Issuance

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -601,4 +601,10 @@
   aia_uri: http://http.fpki.gov/bridge/caCertsIssuedTofbca2016.p7c
   sia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
 
-
+- notice_date: February 20, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime: Issuance date to be determined
+  system: CertiPath Bridge CA G2
+  change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location (http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c)
+  contact: judith dot spencer at certipath dot com
+  

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -608,21 +608,6 @@
   change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location (http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c)
   contact: judith dot spencer at certipath dot com
   
-- notice_date: February 21, 2019
-  change_type: CA Certificate Issuance
-  start_datetime: February 20, 2019
-  end_datetime: February 19, 2022
-  system: STRAC Bridge Root Certification Authority
-  change_description: New cross-certificate issued from STRAC Bridge Root Certification Authority to Federal Bridge 2016
-  contact: pki at strac dot org
-  ca_certificate_hash: EE02BDB684AB4714C5F25300C41C5B8F328B0CD9
-  ca_certificate_issuer: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
-  ca_certificate_subject: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
-  cdp_uri: http://pki.strac.org/bridge/crl/STRACBridgeRootCA.crl
-  aia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
-  sia_uri: http://http.fpki.gov/bridge/caCertsIssuedByfbca2016.p7c
-  ocsp_uri: http://certstatus.strac.org
-
 #- notice_date: 
 #  change_type: CA Certificate Issuance
 #  start_datetime:

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -600,40 +600,5 @@
   cdp_uri: http://http.fpki.gov/bridge/fbca2016.crl
   aia_uri: http://http.fpki.gov/bridge/caCertsIssuedTofbca2016.p7c
   sia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
-  
-- notice_date: February 20, 2019
-  change_type: Intent to Perform CA Certificate Issuance
-  start_datetime: Issuance date to be determined
-  system: CertiPath Bridge CA G2
-  change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location: http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c
-  contact: judith dot spencer at certipath dot com
-  
-- notice_date: February 21, 2019
-  change_type: CA Certificate Issuance
-  start_datetime: February 20, 2019
-  end_datetime: February 19, 2022
-  system: STRAC Bridge Root Certification Authority
-  change_description: New cross-certificate issued from STRAC Bridge Root Certification Authority to Federal Bridge 2016
-  contact: pki at strac dot org
-  ca_certificate_hash: EE02BDB684AB4714C5F25300C41C5B8F328B0CD9
-  ca_certificate_issuer: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
-  ca_certificate_subject: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
-  cdp_uri: http://pki.strac.org/bridge/crl/STRACBridgeRootCA.crl
-  aia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
-  sia_uri: http://http.fpki.gov/bridge/caCertsIssuedByfbca2016.p7c
-  ocsp_uri: http://certstatus.strac.org
 
-#- notice_date: 
-#  change_type: CA Certificate Issuance
-#  start_datetime:
-#  end_datetime: 
-#  system: 
-#  change_description: 
-#  contact: fpki@gsa.gov
-#  ca_certificate_hash:
-#  ca_certificate_issuer: 
-#  ca_certificate_subject:
-#  cdp_uri: 
-#  aia_uri: 
-#  sia_uri: 
-#  ocsp_uri: 
+

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -608,3 +608,32 @@
   change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location (http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c)
   contact: judith dot spencer at certipath dot com
   
+- notice_date: February 21, 2019
+  change_type: CA Certificate Issuance
+  start_datetime: February 20, 2019
+  end_datetime: February 19, 2022
+  system: STRAC Bridge Root Certification Authority
+  change_description: New cross-certificate issued from STRAC Bridge Root Certification Authority to Federal Bridge 2016
+  contact: pki at strac dot org
+  ca_certificate_hash: EE02BDB684AB4714C5F25300C41C5B8F328B0CD9
+  ca_certificate_issuer: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
+  ca_certificate_subject: C=US, O=STRAC, OU=STRAC PKI Trust Infrastructure, CN=STRAC Bridge Root Certification Authority
+  cdp_uri: http://pki.strac.org/bridge/crl/STRACBridgeRootCA.crl
+  aia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
+  sia_uri: http://http.fpki.gov/bridge/caCertsIssuedByfbca2016.p7c
+  ocsp_uri: http://certstatus.strac.org
+
+#- notice_date: 
+#  change_type: CA Certificate Issuance
+#  start_datetime:
+#  end_datetime: 
+#  system: 
+#  change_description: 
+#  contact: fpki@gsa.gov
+#  ca_certificate_hash:
+#  ca_certificate_issuer: 
+#  ca_certificate_subject:
+#  cdp_uri: 
+#  aia_uri: 
+#  sia_uri: 
+#  ocsp_uri: 

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -600,6 +600,13 @@
   cdp_uri: http://http.fpki.gov/bridge/fbca2016.crl
   aia_uri: http://http.fpki.gov/bridge/caCertsIssuedTofbca2016.p7c
   sia_uri: http://pki.strac.org/bridge/certificates/STRACBridgeRootCA.p7c
+  
+ - notice_date: February 20, 2019
+ change_type: Intent to Perform CA Certificate Issuance
+ start_datetime: Issuance date to be determined
+ system: CertiPath Bridge CA G2
+ change_description: CertiPath intends to reissue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman prior to the end of this month. No changes are being made to certificate policies or policy mappings. After testing and vetting, newly issued certificates will be provided to FPKI and published to the CertiPath Bridge CA - G2 SIA location: http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c
+ contact: judith dot spencer at certipath dot com
 
 #- notice_date: 
 #  change_type: CA Certificate Issuance


### PR DESCRIPTION
@lachellel 

This pull request adds notification for CertiPath's intent to issue cross-certificates from the CertiPath Bridge CA G2 to Carillon, NextgenID, and Northrop Grumman. Individual notifications will be added for each of these events, once complete.

Related Issue: #415 

Live Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/fpki-guides/system-notice-2212019/notifications/#notifications