### PR TITLE
Digicert datacenter migration

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -558,7 +558,7 @@
   start_datetime: April 6, 2019
   end_datetime: April 7, 2019
   system: Symantec Managed PKI
-  change_description: DigiCert will be moving their Symantec Managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
+  change_description: DigiCert will be moving the federal PKI shared service provider CAs (government) and other managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
   contact: steve dot medin at digicert dot com 
   ca_certificate_hash:
   ca_certificate_issuer:
@@ -635,11 +635,11 @@
   change_type: Intent to Perform CA Certificate Issuance
   start_datetime: April 7, 2019
   system: US Treasury 
-  change_description: Treasury intends to re-key ou=Social Security Administration Certification Authority, ou=SSA, o=U.S. Government, c=US on 4/7/2019. Certificates will be available following the key update at https://pki.treasury.gov.
+  change_description: Treasury intends to re-key the Social Security Administration CA on 4/7/2019. Certificates will be available following the key update at https://pki.treasury.gov.
   contact: pki dot pmo at fiscal dot treasury dot gov
   ca_certificate_hash:
   ca_certificate_issuer:
-  ca_certificate_subject:
+  ca_certificate_subject: ou=Social Security Administration Certification Authority, ou=SSA, o=U.S. Government, c=US
   cdp_uri:
   aia_uri:
   sia_uri:

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -307,6 +307,21 @@
   cdp_uri: http://certipath-crl.symauth.com/CertiPathBridgeCA-G2.crl
   aia_uri: http://certipath-aia.symauth.com/CertiPathBridgeCA-G2.p7c
   
+- notice_date: February 11, 2019
+  change_type: URI Change (IP addresses)
+  start_datetime: April 6, 2019
+  end_datetime: April 7, 2019
+  system: Symantec Managed PKI
+  change_description: DigiCert will be moving their Symantec Managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
+  contact: steve dot medin at digicert dot com 
+  ca_certificate_hash:
+  ca_certificate_issuer:
+  ca_certificate_subject:
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri: 
+  
 - notice_date: April 4, 2018
   change_type: CA Certificate Revocation
   start_datetime: March 26, 2018 12:15 PM

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -635,7 +635,7 @@
   change_type: Intent to Perform CA Certificate Issuance
   start_datetime: April 7, 2019
   system: US Treasury 
-  change_description: Treasury intends to re-key ou=OCIO CA, ou=Certification Authorities, ou=Department of the Treasury, o=U.S. Government, c=US and ou=Social Security Administration Certification Authority, ou=SSA, o=U.S. Government, c=US on 4/7/2019. Certificates will be available following the key update at https://pki.treasury.gov.
+  change_description: Treasury intends to re-key ou=Social Security Administration Certification Authority, ou=SSA, o=U.S. Government, c=US on 4/7/2019. Certificates will be available following the key update at https://pki.treasury.gov.
   contact: pki dot pmo at fiscal dot treasury dot gov
   ca_certificate_hash:
   ca_certificate_issuer:
@@ -762,6 +762,20 @@
   aia_uri: http://ssp-aia.digicert.com/SSP/Certs_issued_to_SSPCAG5.p7c
   sia_uri:
   ocsp_uri: http://ssp-ocsp.digicert.com
+  
+- notice_date: March 13, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime: June 29, 2019
+  system: US Treasury 
+  change_description: Treasury intends to re-key ou=OCIO CA, ou=Certification Authorities, ou=Department of the Treasury, o=U.S. Government, c=US on 6/29/2019. Certificates will be available following the key update at https://pki.treasury.gov.
+  contact: pki dot pmo at fiscal dot treasury dot gov
+  ca_certificate_hash:
+  ca_certificate_issuer:
+  ca_certificate_subject:
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri:
   
 #- notice_date: 
 #  change_type: CA Certificate Issuance

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -306,22 +306,7 @@
   ca_certificate_subject: CN = CISRCA1, OU = Certification Authorities, O = Carillon Information Security Inc., C = CA
   cdp_uri: http://certipath-crl.symauth.com/CertiPathBridgeCA-G2.crl
   aia_uri: http://certipath-aia.symauth.com/CertiPathBridgeCA-G2.p7c
-  
-- notice_date: February 11, 2019
-  change_type: URI Change (IP addresses)
-  start_datetime: April 6, 2019
-  end_datetime: April 7, 2019
-  system: Symantec Managed PKI
-  change_description: DigiCert will be moving their Symantec Managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
-  contact: steve dot medin at digicert dot com 
-  ca_certificate_hash:
-  ca_certificate_issuer:
-  ca_certificate_subject:
-  cdp_uri:
-  aia_uri:
-  sia_uri:
-  ocsp_uri: 
-  
+    
 - notice_date: April 4, 2018
   change_type: CA Certificate Revocation
   start_datetime: March 26, 2018 12:15 PM
@@ -567,6 +552,22 @@
   system: FPKI Trust Infrastructure - Federal Bridge 2016
   change_description: New cross-certificate planned for issuance from Federal Bridge CA 2016 to DigiCert Federated ID L3 CA
   contact: fpki at gsa dot gov
+
+- notice_date: February 11, 2019
+  change_type: URI Change (IP addresses)
+  start_datetime: April 6, 2019
+  end_datetime: April 7, 2019
+  system: Symantec Managed PKI
+  change_description: DigiCert will be moving their Symantec Managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
+  contact: steve dot medin at digicert dot com 
+  ca_certificate_hash:
+  ca_certificate_issuer:
+  ca_certificate_subject:
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri: 
+
 
 - notice_date: February 12, 2019
   change_type: Intent to Perform CA Certificate Revocation

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -767,11 +767,11 @@
   change_type: Intent to Perform CA Certificate Issuance
   start_datetime: June 29, 2019
   system: US Treasury 
-  change_description: Treasury intends to re-key ou=OCIO CA, ou=Certification Authorities, ou=Department of the Treasury, o=U.S. Government, c=US on 6/29/2019. Certificates will be available following the key update at https://pki.treasury.gov.
+  change_description: Treasury intends to re-key the Treasury OCIO CA (TOCA) on 6/29/2019. Certificates will be available following the key update at https://pki.treasury.gov.
   contact: pki dot pmo at fiscal dot treasury dot gov
   ca_certificate_hash:
   ca_certificate_issuer:
-  ca_certificate_subject:
+  ca_certificate_subject: ou=OCIO CA, ou=Certification Authorities, ou=Department of the Treasury, o=U.S. Government, c=US
   cdp_uri:
   aia_uri:
   sia_uri:


### PR DESCRIPTION
@lachellel 

Added notification for: https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html

```
Change Summary:
Notice date: February 11, 2019
System: Symantec Managed PKI
Type: URI Change (IP addresses)
Start Date and Time: April 6, 2019
Change Description: DigiCert will be moving their Symantec Managed PKI to new data centers. The address ranges in the new data centers will be as follows - 216.168.245.0/24, 216.168.246.0/24, 216.168.248.0/24, and 216.168.249.0/24. Be prepared to update network configurations as necessary. This activity is planned to take place between 15:30 UTC, April 6, 2019 and 3:30 UTC, April 7, 2019. See https://knowledge.digicert.com/generalinformation/digicert-symantec-managed-pki-data-center-migration-information-.html for more information.
Contact: steve dot medin at digicert dot com
```

I inherited the notice date from the issue ( #439 ) - did not see anything listed elsewhere.

Live Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/fpki-guides/digicert-datacenter-migration/notifications/

Thanks,
Ryan