### PR TITLE
FPKI Activity Report April 2019

### DIFF
--- a/_includes/fpkiar-repo-table.html
+++ b/_includes/fpkiar-repo-table.html
@@ -21,7 +21,7 @@ No Issues - Green - d52n (USDS - #FF99AF | Guide - #e7f4e4)
     <tr>
         <th class="tg-llyw">Federal Agency or Affiliate CA</th>
         <td class="tg-llyw">FPKIMA CA</td>
-        <td class="tg-llyw">Mar 2019</td>
+        <td class="tg-llyw">Aor 2019</td>
         <td class="tg-llyw">Average</td>
     </tr>
     <tr>
@@ -33,187 +33,181 @@ No Issues - Green - d52n (USDS - #FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-y698">CT-CSSP-CA-A1</td>
         <td class="tg-y698">FBCA</td>
-        <td class="tg-y698">100</td>
-        <td class="tg-y698">100</td>
+        <td class="tg-s7ni">99.92</td>
+        <td class="tg-s7ni">99.99</td>
     </tr>
     <tr>
-        <td class="tg-0pky">DigiCert Federated ID CA-1</td>
+        <td class="tg-s7ni">DigiCert Federated ID CA-1</td>
+        <td class="tg-s7ni">FBCA</td>
+        <td class="tg-s7ni">Removed</td>
+        <td class="tg-s7ni">100</td>
+    </tr>
+    <tr>
+        <td class="tg-s7ni">DigiCert Federated ID L3 CA</td>
+        <td class="tg-s7ni">FBCA</td>
+        <td class="tg-s7ni">Added</td>
+        <td class="tg-s7ni">100</td>
+    </tr>
+    <tr>
+        <td class="tg-0pky">DoD Interoperability Root CA 2</td>
         <td class="tg-0pky">FBCA</td>
         <td class="tg-0pky">100</td>
-        <td class="tg-0pky">100</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">DoD Interoperability Root CA 2</td>
-        <td class="tg-y698">FBCA</td>
-        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.92</td>
     </tr>
     <tr>
-        <td class="tg-0pky">Entrust Managed Services NFI Root CA</td>
-        <td class="tg-0pky">FBCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-0pky">100</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">Entrust Managed Services NFI Root CA 2</td>
+        <td class="tg-y698">Entrust Managed Services NFI Root CA</td>
         <td class="tg-y698">FBCA</td>
         <td class="tg-y698">100</td>
         <td class="tg-y698">100</td>
     </tr>
-    <tr>
-        <td class="tg-0pky">Exostar Federated Identity Service Root CA 2</td>
+     <tr>
+        <td class="tg-0pky">Exostar Federated Identity Service Root CA</td>
         <td class="tg-0pky">FBCA</td>
         <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.99</td>
     </tr>
     <tr>
-        <td class="tg-y698">Federal Bridge CA 2013</td>
+        <td class="tg-y698">Federal Bridge CA 2016</td>
         <td class="tg-y698">FBCA</td>
         <td class="tg-y698">100</td>
         <td class="tg-y698">100</td>
     </tr>
     <tr>
-        <td class="tg-0pky">Federal Bridge CA 2016</td>
+        <td class="tg-0pky">GPO PCA</td>
         <td class="tg-0pky">FBCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-0pky">100</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">GPO PCA</td>
-        <td class="tg-y698">FBCA</td>
         <td class="tg-s7ni">97.07</td>
         <td class="tg-s7ni">99.59</td>
     </tr>
     <tr>
-        <td class="tg-0pky">IdenTrust ACES 2</td>
-        <td class="tg-0pky">FBCA</td>
-        <td class="tg-0pky">100</td>
+        <td class="tg-y698">IdenTrust ACES 2</td>
+        <td class="tg-y698">FBCA</td>
+        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.99</td>
     </tr>
     <tr>
-        <td class="tg-y698">IdenTrust Global Common Root CA 1</td>
-        <td class="tg-y698">FBCA</td>
-        <td class="tg-y698">100</td>
+        <td class="tg-0pky">IdenTrust Global Common Root CA 1</td>
+        <td class="tg-0pky">FBCA</td>
+        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.87</td>
     </tr>
     <tr>
-        <td class="tg-0pky">ORC ACES 4 CA</td>
-        <td class="tg-0pky">FBCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-s7ni">99.98</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">ORC NFI 2 CA</td>
+        <td class="tg-y698">ORC ACES 4 CA</td>
         <td class="tg-y698">FBCA</td>
         <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.98</td>
     </tr>
     <tr>
-        <td class="tg-0pky">ORC NFI 3 CA</td>
+        <td class="tg-0pky">ORC NFI 2 CA</td>
         <td class="tg-0pky">FBCA</td>
         <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.98</td>
     </tr>
     <tr>
-        <td class="tg-y698">SAFE Bridge CA 02</td>
+        <td class="tg-y698">ORC NFI 3 CA</td>
         <td class="tg-y698">FBCA</td>
         <td class="tg-y698">100</td>
-        <td class="tg-y698">100</td>
-    </tr>
-    <tr>
-        <td class="tg-0pky">STRAC Bridge Root Certification Authority</td>
-        <td class="tg-0pky">FBCA</td>
-        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.98</td>
     </tr>
     <tr>
-        <td class="tg-y698">Symantec Class 3 SSP Intermediate CA - G3</td>
-        <td class="tg-y698">FBCA</td>
-        <td class="tg-y698">100</td>
-        <td class="tg-s7ni">99.79</td>
+        <td class="tg-0pky">SAFE Bridge CA 02</td>
+        <td class="tg-0pky">FBCA</td>
+        <td class="tg-0pky">100</td>
+        <td class="tg-0pky">100</td>
     </tr>
     <tr>
-        <td class="tg-0pky">TSCP SHA256 Bridge CA</td>
+        <td class="tg-y698">STRAC Bridge Root Certification Authority</td>
+        <td class="tg-y698">FBCA</td>
+        <td class="tg-s7ni">99.75</td>
+        <td class="tg-s7ni">99.96</td>
+    </tr>
+    <tr>
+        <td class="tg-0pky">Symantec Class 3 SSP Intermediate CA - G3</td>
+        <td class="tg-0pky">FBCA</td>
+        <td class="tg-s7ni">94.38</td>
+        <td class="tg-s7ni">99.32</td>
+    </tr>
+    <tr>
+        <td class="tg-y698">TSCP SHA256 Bridge CA</td>
+        <td class="tg-y698">FBCA</td>
+        <td class="tg-y698">100</td>
+        <td class="tg-s7ni">100</td>
+    </tr>
+    <tr>
+        <td class="tg-0pky">USPTO_INTR_CA1</td>
         <td class="tg-0pky">FBCA</td>
         <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.99</td>
     </tr>
     <tr>
-        <td class="tg-y698">USPTO_INTR_CA1</td>
-        <td class="tg-y698">FBCA</td>
-        <td class="tg-y698">100</td>
-        <td class="tg-s7ni">99.99</td>
-    </tr>
-    <tr>
-        <td class="tg-0pky">DigiCert Intermediate SSP CA - G5</td>
-        <td class="tg-0pky">FCPCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-s7ni">99.76</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">Entrust Managed Services Root CA</td>
+        <td class="tg-y698">DigiCert Intermediate SSP CA - G5</td>
         <td class="tg-y698">FCPCA</td>
-        <td class="tg-y698">100</td>
-        <td class="tg-y698">100</td>
+        <td class="tg-s7ni">98.57</td>
+        <td class="tg-s7ni">99.46</td>
     </tr>
     <tr>
-        <td class="tg-0pky">Federal Common Policy CA</td>
+        <td class="tg-0pky">Entrust Managed Services Root CA</td>
         <td class="tg-0pky">FCPCA</td>
         <td class="tg-0pky">100</td>
         <td class="tg-0pky">100</td>
     </tr>
     <tr>
-        <td class="tg-y698">ORC SSP 4</td>
+        <td class="tg-y698">Federal Common Policy CA</td>
         <td class="tg-y698">FCPCA</td>
         <td class="tg-y698">100</td>
+        <td class="tg-y698">100</td>
+    </tr>
+    <tr>
+        <td class="tg-0pky">ORC SSP 4</td>
+        <td class="tg-0pky">FCPCA</td>
+        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.98</td>
     </tr>
     <tr>
-        <td class="tg-0pky">Symantec SSP Intermediate CA - G4</td>
-        <td class="tg-0pky">FCPCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-s7ni">99.65</td>
+        <td class="tg-y698">Symantec SSP Intermediate CA - G4</td>
+        <td class="tg-y698">FCPCA</td>
+        <td class="tg-s7ni">93.17</td>
+        <td class="tg-s7ni">99.08</td>
     </tr>
     <tr>
-        <td class="tg-y698">U.S. Department of State AD Root CA</td>
-        <td class="tg-y698">FCPCA</td>        
-        <td class="tg-y698">100</td>
+        <td class="tg-0pky">U.S. Department of State AD Root CA</td>
+        <td class="tg-0pky">FCPCA</td>        
+        <td class="tg-0pky">100</td>
         <td class="tg-s7ni">99.99</td>
     </tr>
     <tr>
-        <td class="tg-0pky">US Treasury Root CA</td>
-        <td class="tg-0pky">FCPCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-0pky">100</td>
-    </tr>
-    <tr>
-        <td class="tg-y698">Verisign SSP Intermediate CA - G3</td>
+        <td class="tg-y698">US Treasury Root CA</td>
         <td class="tg-y698">FCPCA</td>
         <td class="tg-y698">100</td>
-        <td class="tg-s7ni">99.65</td>
+        <td class="tg-y698">100</td>
     </tr>
     <tr>
-        <td class="tg-0pky">Verizon SSP CA A2</td>
+        <td class="tg-0pky">Verisign SSP Intermediate CA - G3</td>
         <td class="tg-0pky">FCPCA</td>
-        <td class="tg-0pky">100</td>
-        <td class="tg-0pky">100</td>
+        <td class="tg-s7ni">98.57</td>
+        <td class="tg-s7ni">99.53</td>
     </tr>
     <tr>
-        <td class="tg-y698">CertiPath Bridge CA</td>
-        <td class="tg-y698">SHA1FRCA</td>
+        <td class="tg-y698">Verizon SSP CA A2</td>
+        <td class="tg-y698">FCPCA</td>
         <td class="tg-y698">100</td>
         <td class="tg-y698">100</td>
     </tr>
     <tr>
-        <td class="tg-0pky">DoD Interoperability Root CA 1</td>
+        <td class="tg-0pky">CertiPath Bridge CA</td>
         <td class="tg-0pky">SHA1FRCA</td>
         <td class="tg-0pky">100</td>
+        <td class="tg-0pky">100</td>
+    </tr>
+    <tr>
+        <td class="tg-y698">DoD Interoperability Root CA 1</td>
+        <td class="tg-y698">SHA1FRCA</td>
+        <td class="tg-y698">100</td>
         <td class="tg-s7ni">99.93</td>
     </tr>
     <tr>
-        <td class="tg-y698">SHA-1 Federal Root CA G2</td>
-        <td class="tg-y698">SHA1FRCA</td>
-        <td class="tg-y698">100</td>
-        <td class="tg-y698">100</td>
+        <td class="tg-0pky">SHA-1 Federal Root CA G2</td>
+        <td class="tg-0pky">SHA1FRCA</td>
+        <td class="tg-0pky">100</td>
+        <td class="tg-0pky">100</td>
     </tr>
 </table>

--- a/_includes/fpkiar-repo-table.html
+++ b/_includes/fpkiar-repo-table.html
@@ -39,14 +39,12 @@ No Issues - Green - d52n (USDS - #FF99AF | Guide - #e7f4e4)
     <tr>
         <td class="tg-s7ni">DigiCert Federated ID CA-1</td>
         <td class="tg-s7ni">FBCA</td>
-        <td class="tg-s7ni">Removed</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-s7ni" colspan="2">Removed</td>
     </tr>
     <tr>
         <td class="tg-s7ni">DigiCert Federated ID L3 CA</td>
         <td class="tg-s7ni">FBCA</td>
-        <td class="tg-s7ni">Added</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-s7ni" colspan="2">Added</td>
     </tr>
     <tr>
         <td class="tg-0pky">DoD Interoperability Root CA 2</td>

--- a/_includes/fpkiar-repo-table.html
+++ b/_includes/fpkiar-repo-table.html
@@ -128,7 +128,7 @@ No Issues - Green - d52n (USDS - #FF99AF | Guide - #e7f4e4)
         <td class="tg-y698">TSCP SHA256 Bridge CA</td>
         <td class="tg-y698">FBCA</td>
         <td class="tg-y698">100</td>
-        <td class="tg-s7ni">100</td>
+        <td class="tg-y698">100</td>
     </tr>
     <tr>
         <td class="tg-0pky">USPTO_INTR_CA1</td>

--- a/_tools/03_fpki_activity_report.md
+++ b/_tools/03_fpki_activity_report.md
@@ -5,7 +5,7 @@ collection: tools
 permalink: tools/fpkiactivityreport/
 ---
 
-Updated: April 3, 2019
+Updated: May 6, 2019
 
 This report provides a technical and policy compliance status for each Federal Public Key Infrastructure (FPKI) Affiliate.
 
@@ -15,7 +15,7 @@ This report provides a technical and policy compliance status for each Federal P
 
 Resolve issues by contacting one of the teams:  
 
-- Technical issues contact the [FPKIMA Team](mailto:fpkipa-ma@listserv.gsa.gov) 
+- Technical issues contact the [FPKIMA Team](mailto:fpki-help@gsa.gov) 
 - Certificate Policy issues contact the [Certificate Policy Working Group (CPWG)](mailto:fpkipa_cpwg@listserv.gsa.gov)  
 
 ## Federal Agency and Affiliate PKI Status Summary
@@ -30,19 +30,20 @@ The following certificates were issued **BY** or **TO** the FPKI Trust Infrastru
 
 | Affiliate | Subject CA | Issuing CA | SHA-1 Hash | Issued Date |
 | --------- | ---------- | ---------- | ------ | ------ |
-| Treasury | Treasury Root CA | Federal Common Policy CA | fa392ea2972eb4edd1929932602a1909ac9558bc | 04/02/2019 |
+| CertiPath Bridge | Federal Bridge CA 2016 | CertiPath Bridge CA - G2 | FCE64C867D1AF8E1C1FF5B07A869AF5F3E6F823F | 04/22/2019 |
 
 The following certificates have been removed from the FPKI Trust Infrastructure in the last 30 days.
 
 | Affiliate | Subject CA | Issuing CA | SHA-1 Hash | Expiration Date |
 | --------- | ---------- | ---------- | ------ | ------ |
-| Verizon | Verizon  | Federal Common Policy CA | a9d3a8ac016dba9fa12685bf59dcc39f5dcaf781 | 12/06/2026 |
+| CertiPath Bridge | Federal Bridge CA 2016 | CertiPath Bridge CA - G2 | 6305CFA15E6E6AD972847251B6930FEA8D6087DB | 04/30/2019 |
 
 The following certificates are expiring in the next four months and may be re-issued.
 
 | Affiliate | Subject CA | Issuing CA | SHA-1 Hash | Expiration Date |
 | --------- | ---------- | ---------- | ------ | ---------- |
-| CertiPath Bridge | Federal Bridge CA 2016 | CertiPath Bridge CA - G2 | 6305CFA15E6E6AD972847251B6930FEA8D6087DB | 04/30/2019 |
+| DoD | DoD Interoperability Root CA 2 | Federal Bridge CA 2016 | 949E7F407D71EEE663709D5D2A680460146CE530 | 08/15/2019 |
+| TSCP | TSCP SHA256 Bridge CA | Federal Bridge CA 2016 | 949E7F407D71EEE663709D5D2A680460146CE530 | 08/11/2019 |
 
 ## Repository Availability 
 Respository availability is an uptime metric for Certificate Revocation List availability. The table only contains Certification Authorities directly certified with the FPKIMA. A metric of "99" in the table below means the Certificate Revocation List was available for 99% of the given month, in other words, the file was not available for 1% of the month (18 minutes depending on the month). The last column is the 12-Month average.


### PR DESCRIPTION
Activity Report update for April 2019 activity:

1. DoD and TSCP expiring in four months.
2. Availability reporting updates.