### PR TITLE
DHS CA4 Re-Key Update

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1011,7 +1011,7 @@
   sia_uri: http://pki.treasury.gov/dhsca_sia.p7c
   ocsp_uri:
 
-#- notice_date: 
+#- notice_date:  
 #  change_type: CA Certificate Issuance
 #  start_datetime:
 #  end_datetime: 

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -997,6 +997,19 @@
   sia_uri: 
   ocsp_uri: http://ocsp.disa.mil
 
+- notice_date: June 6, 2019
+  change_type: CA Certificate Issuance
+  start_datetime: June 6, 2019
+  system: Department of Homeland Security Certification Authority (DHSCA)
+  change_description: DHS re-keyed the DHSCA on June 6, 2019. DHS communicated the intent to re-key this CA on April 20, 2019. The new certificate is available at https://pki.treasury.gov/crl_certs.htm
+  contact:  gladys dot garcia at hq dot dhs dot gov
+  ca_certificate_hash: 58085a64e181573f4fd917c5c021eb1cf344dd5f
+  ca_certificate_issuer: OU = US Treasury Root CA, OU = Certification Authorities, OU = Department of the Treasury, O = U.S. Government, C = US
+  ca_certificate_subject: OU = DHS CA4, OU = Certification Authorities, OU = Department of Homeland Security, O = U.S. Government, C = US
+  cdp_uri: http://pki.treasury.gov/US_Treasury_Root_CA1.crl
+  aia_uri: http://pki.treasury.gov/dhsca_aia.p7c
+  sia_uri: http://pki.treasury.gov/dhsca_sia.p7c
+  ocsp_uri:
 
 #- notice_date: 
 #  change_type: CA Certificate Issuance


### PR DESCRIPTION
@lachellel 

As discussed earlier, please find a new system notification to mark the completion of the DHS re-key event (#466).

**New certificate details:**
Validity: June 6, 2019, 7:11 a.m. - June 6, 2029, 7:41 a.m.
Serial #: 5CCB31CA
SHA1: 58085A64E181573F4FD917C5C021EB1CF344DD5F
SHA256: 1F876321693113EA500050531A755716F196DC05EAD8499E794D341F6CB44515

**Live Preview:** https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/fpki-guides/dhsca4-update/notifications/#notifications

Thanks,
Ryan

