### PR TITLE
System notification 07252019

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1137,6 +1137,33 @@
   sia_uri: http://ssp-sia.symauth.com/STNSSP/Certs_Issued_by_Class3SSPCA-G3.p7c
   ocsp_uri: http://ssp-ocsp.symauth.com
 
+- notice_date: July 23, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime:  
+  system: Entrust Managed Services
+  change_description: Entrust intends to re-key both the Entrust Managed Services Root CA and the Entrust Managed Services SSP CA. The re-key events are tentatively planned for mid-August.  Entrust also communicated intent to request a new cross-certificate from the Federal Common Policy CA to the Entrust Managed Services Root CA, once the re-key is complete.  This notification will be updated as Entrust communicates the finalized event timeline with the Federal PKI Support Team.
+  contact: Cris dot TenEyck at entrustdatacard dot com and Howard dot Freitag at entrustdatacard dot com
+  ca_certificate_hash:  
+  ca_certificate_issuer: ou=Entrust Managed Services Root CA, ou=Certification Authorities, o=Entrust, c=US
+  ca_certificate_subject: Two certificates are planned for issuance (1) ou=Entrust Managed Services Root CA, ou=Certification Authorities and (2) o=Entrust, c=US and ou=Entrust Managed Services SSP CA, ou=Certification Authorities, o=Entrust, c=US
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri:
+  
+- notice_date: July 24, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime:  
+  system: FPKI Trust Infrastructure - Federal Bridge 2016
+  change_description: The Federal Bridge CA 2016 intends to issue cross-certificates to DoD Interoperability Root CA 2, TSCP SHA256 Bridge CA, and WidePoint NFI Root CA 1. Certificate issuance is expected to take place before August 15, 2019.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash:  
+  ca_certificate_issuer: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
+  ca_certificate_subject: Three certificates are planned for issuance. (1) CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US, (2) CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US, and (3) CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri:
 
 #- notice_date:  
 #  change_type: CA Certificate Issuance

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1164,6 +1164,15 @@
   aia_uri:
   sia_uri:
   ocsp_uri:
+  
+- notice_date: July 25, 2019
+  change_type: Intent to Perform CA Certificate Revocation
+  system: FPKI Trust Infrastructure - Federal Bridge 2016
+  change_description: The Federal Bridge CA 2016 intends to revoke the cross-certificate issued to CN = CT-CSSP-CA-A1, OU = PKI, OU = Services, O = Cybertrust, C = US (operated by Verizon NFI).
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 68 70 66 bc e5 6b 6e 20 ae a0 c6 05 b9 b6 67 93 42 26 9f 21
+  ca_certificate_issuer: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
+  ca_certificate_subject: CN = CT-CSSP-CA-A1, OU = PKI, OU = Services, O = Cybertrust, C = US
 
 #- notice_date:  
 #  change_type: CA Certificate Issuance

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1159,7 +1159,7 @@
   contact: fpki dash help at gsa dot gov
   ca_certificate_hash:  
   ca_certificate_issuer: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
-  ca_certificate_subject: Three certificates are planned for issuance. (1) CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US, (2) CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US, and (3) CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US
+  ca_certificate_subject: Three certificates are planned for issuance (1) CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US, (2) CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US, and (3) CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US
   cdp_uri:
   aia_uri:
   sia_uri:

--- a/_includes/apple_trust_store_installation.md
+++ b/_includes/apple_trust_store_installation.md
@@ -85,7 +85,7 @@ These steps will help you to create, distribute, and install profiles using Appl
 
 To use this profile, copy the XML information and save it as a `.mobileconfig` file. 
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
@lachellel - This PR will add two new system notifications:

1. #528 - **Entrust** re-key event (ou=Entrust Managed Services Root CA, ou=Certification Authorities and  o=Entrust, c=US and ou=Entrust Managed Services SSP CA, ou=Certification)
2. #530 - **Federal Bridge CA 2016** issuance to DoD (CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US), TSCP (CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US), and WidePoint (CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US).

I'm monitoring the activities above and will add notifications upon their completion. 

I've also setup calendar reminders on the team calendar to track these events, in addition to #473 (pending confirmation of authorization from Verizon) and the eventual Common -> re-keyed Entrust Managed Services Root CA (both intent to obtain cross-cert + issuance).

Live Preview: https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/fpki-guides/system-notification-07252019/notifications/#notifications

Please let me know if there are any questions.

Thanks,
Ryan