### PR TITLE
20190729 auto fpki graph update

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1165,6 +1165,24 @@
   sia_uri:
   ocsp_uri:
 
+- notice_date: July 25, 2019
+  change_type: Intent to Perform CA Certificate Revocation
+  system: FPKI Trust Infrastructure - Federal Bridge 2016
+  change_description: The Federal Bridge CA 2016 intends to revoke the cross-certificate issued to CN = CT-CSSP-CA-A1, OU = PKI, OU = Services, O = Cybertrust, C = US (operated by Verizon NFI).
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 68 70 66 bc e5 6b 6e 20 ae a0 c6 05 b9 b6 67 93 42 26 9f 21
+  ca_certificate_issuer: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
+  ca_certificate_subject: CN = CT-CSSP-CA-A1, OU = PKI, OU = Services, O = Cybertrust, C = US
+  
+- notice_date: July 26, 2019
+  change_type: Intent to Perform CA Certificate Revocation
+  system: Verizon NFI
+  change_description: Verizon NFI intends to revoke the cross-certificate issued from CT-CSSP-CA-A1 to the Federal Bridge CA 2016.
+  contact: andre dot varacka at verizon dot com
+  ca_certificate_hash: 73 dc cf 64 18 52 2b 69 a5 0a 96 72 1a eb 96 44 1e 6e f3 c0 
+  ca_certificate_issuer: CN = CT-CSSP-CA-A1, OU = PKI, OU = Services, O = Cybertrust, C = US
+  ca_certificate_subject: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
+
 #- notice_date:  
 #  change_type: CA Certificate Issuance
 #  start_datetime:

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1137,6 +1137,33 @@
   sia_uri: http://ssp-sia.symauth.com/STNSSP/Certs_Issued_by_Class3SSPCA-G3.p7c
   ocsp_uri: http://ssp-ocsp.symauth.com
 
+- notice_date: July 23, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime:  
+  system: Entrust Managed Services
+  change_description: Entrust intends to re-key both the Entrust Managed Services Root CA and the Entrust Managed Services SSP CA. The re-key events are tentatively planned for mid-August.  Entrust also communicated intent to request a new cross-certificate from the Federal Common Policy CA to the Entrust Managed Services Root CA, once the re-key is complete.  This notification will be updated as Entrust communicates the finalized event timeline with the Federal PKI Support Team.
+  contact: Cris dot TenEyck at entrustdatacard dot com and Howard dot Freitag at entrustdatacard dot com
+  ca_certificate_hash:  
+  ca_certificate_issuer: ou=Entrust Managed Services Root CA, ou=Certification Authorities, o=Entrust, c=US
+  ca_certificate_subject: Two certificates are planned for issuance (1) ou=Entrust Managed Services Root CA, ou=Certification Authorities and (2) o=Entrust, c=US and ou=Entrust Managed Services SSP CA, ou=Certification Authorities, o=Entrust, c=US
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri:
+
+- notice_date: July 24, 2019
+  change_type: Intent to Perform CA Certificate Issuance
+  start_datetime:  
+  system: FPKI Trust Infrastructure - Federal Bridge 2016
+  change_description: The Federal Bridge CA 2016 intends to issue cross-certificates to DoD Interoperability Root CA 2, TSCP SHA256 Bridge CA, and WidePoint NFI Root CA 1. Certificate issuance is expected to take place before August 15, 2019.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash:  
+  ca_certificate_issuer: CN = Federal Bridge CA 2016, OU = FPKI, O = U.S. Government, C = US
+  ca_certificate_subject: Three certificates are planned for issuance. (1) CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US, (2) CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US, and (3) CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US
+  cdp_uri:
+  aia_uri:
+  sia_uri:
+  ocsp_uri:
 
 #- notice_date:  
 #  change_type: CA Certificate Issuance

--- a/_includes/apple_trust_store_installation.md
+++ b/_includes/apple_trust_store_installation.md
@@ -85,7 +85,7 @@ These steps will help you to create, distribute, and install profiles using Appl
 
 To use this profile, copy the XML information and save it as a `.mobileconfig` file. 
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -4,7 +4,7 @@ title: Federal PKI Graph
 collection: tools
 permalink: tools/fpkigraph/
 ---
-**Last Update**: July 22, 2019
+**Last Update**: July 29, 2019
 {% include graph.html %}
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  

--- a/_tools/fpki-certs.gexf
+++ b/_tools/fpki-certs.gexf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
-  <meta lastmodifieddate="2019-07-22">
+  <meta lastmodifieddate="2019-07-29">
     <creator>Gephi 0.8.1</creator>
     <description></description>
   </meta>
@@ -21,55 +21,55 @@
       <node id="CN=Alexion Pharmaceuticals Root CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" label="Alexion Pharmaceuticals Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="499.9706" y="3.744708E-24" z="0.0"></viz:position>
+        <viz:position x="499.9706" y="1.3459647E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G2,OU=certservers,O=Boeing,C=US" label="Boeing PCA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="223.43414" y="-200.18916" z="0.0"></viz:position>
+        <viz:position x="223.43414" y="-200.21457" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" label="Boeing PCA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="156.29326" y="-256.0636" z="0.0"></viz:position>
+        <viz:position x="156.29326" y="-256.11444" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton Device CA 02,OU=Certification Authorities,O=Booz Allen Hamilton,C=US" label="Booz Allen Hamilton Device CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-208.25113" y="-215.95709" z="0.0"></viz:position>
+        <viz:position x="-208.22572" y="-215.95709" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton PIVi CA 01,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="Booz Allen Hamilton PIVi CA 01">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="191.89828" y="-230.58058" z="0.0"></viz:position>
+        <viz:position x="191.92369" y="-230.58058" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Bureau of the Census Agency CA,OU=Department of Commerce,O=U.S. Government,C=US" label="Bureau of the Census Agency CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="141.41547" y="-141.41547" z="0.0"></viz:position>
+        <viz:position x="141.44089" y="-141.44089" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="32.817005" y="298.19196" z="0.0"></viz:position>
+        <viz:position x="32.81065" y="298.19196" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-51.770313" y="193.16989" z="0.0"></viz:position>
+        <viz:position x="-51.770313" y="193.1953" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-184.77728" y="-76.53169" z="0.0"></viz:position>
+        <viz:position x="-184.80269" y="-76.5444" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Common Policy Root Certification Authority - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Common Policy Root Certification Authority - G2">
@@ -81,7 +81,7 @@
       <node id="CN=CertiPath Common Policy Root Certification Authority,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Common Policy Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="32.81065" y="-298.19196" z="0.0"></viz:position>
+        <viz:position x="32.817005" y="-298.19196" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CISRCA1,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="CISRCA1">
@@ -99,7 +99,7 @@
       <node id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="99.99285" y="8.066442E-25" z="0.0"></viz:position>
+        <viz:position x="99.99285" y="2.0008818E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federated ID L3 CA,OU=www.digicert.com,O=DigiCert Inc,C=US" label="DigiCert Federated ID L3 CA">
@@ -111,13 +111,13 @@
       <node id="CN=DocuSign Root CA,OU=TSCP,O=DocuSign Inc.,C=US" label="DocuSign Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-96.8647" y="283.94992" z="0.0"></viz:position>
+        <viz:position x="-96.8647" y="283.89908" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-33,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-33">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="396.4109" y="-53.31532" z="0.0"></viz:position>
+        <viz:position x="396.4109" y="-53.321674" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-34,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-34">
@@ -129,19 +129,19 @@
       <node id="CN=DOD EMAIL CA-39,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-39">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="40.039738" y="-397.9877" z="0.0"></viz:position>
+        <viz:position x="40.033382" y="-398.03854" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-40,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-40">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="278.10052" y="-287.51044" z="0.0"></viz:position>
+        <viz:position x="278.04968" y="-287.51044" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-13.366978" y="399.76794" z="0.0"></viz:position>
+        <viz:position x="-13.365389" y="399.76794" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-42">
@@ -159,7 +159,7 @@
       <node id="CN=DOD EMAIL CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-168.37354" y="362.84045" z="0.0"></viz:position>
+        <viz:position x="-168.39896" y="362.84045" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-49">
@@ -177,7 +177,7 @@
       <node id="CN=DOD EMAIL CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.2289" y="-350.78564" z="0.0"></viz:position>
+        <viz:position x="192.2289" y="-350.83646" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-52">
@@ -189,25 +189,25 @@
       <node id="CN=DOD EMAIL CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="385.78027" y="105.689644" z="0.0"></viz:position>
+        <viz:position x="385.78027" y="105.67693" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-33,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-33">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="396.46173" y="53.31532" z="0.0"></viz:position>
+        <viz:position x="396.4109" y="53.31532" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-34,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-34">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-356.9911" y="180.40295" z="0.0"></viz:position>
+        <viz:position x="-356.9911" y="180.42836" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-39,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-39">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="40.039738" y="397.9877" z="0.0"></viz:position>
+        <viz:position x="40.033382" y="397.9877" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-40,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-40">
@@ -219,7 +219,7 @@
       <node id="CN=DOD ID CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-168.39896" y="-362.84045" z="0.0"></viz:position>
+        <viz:position x="-168.37354" y="-362.84045" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-42">
@@ -243,19 +243,19 @@
       <node id="CN=DOD ID CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-118.507454" y="-382.0163" z="0.0"></viz:position>
+        <viz:position x="-118.520164" y="-382.06714" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="278.10052" y="287.51044" z="0.0"></viz:position>
+        <viz:position x="278.04968" y="287.56128" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="92.71925" y="-389.13727" z="0.0"></viz:position>
+        <viz:position x="92.71925" y="-389.08646" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-52">
@@ -267,7 +267,7 @@
       <node id="CN=DOD ID CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-391.98572" y="79.67256" z="0.0"></viz:position>
+        <viz:position x="-392.03653" y="79.67256" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-35,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-35">
@@ -279,7 +279,7 @@
       <node id="CN=DOD ID SW CA-36,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-36">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="237.26923" y="321.99643" z="0.0"></viz:position>
+        <viz:position x="237.29465" y="321.99643" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-37,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-37">
@@ -291,7 +291,7 @@
       <node id="CN=DOD ID SW CA-38,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-38">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-13.366978" y="-399.76794" z="0.0"></viz:position>
+        <viz:position x="-13.365389" y="-399.76794" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-45,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-45">
@@ -309,13 +309,13 @@
       <node id="CN=DoD Interoperability Root CA 1,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="26.107689" y="-198.30716" z="0.0"></viz:position>
+        <viz:position x="26.107689" y="-198.28175" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="141.44089" y="141.41547" z="0.0"></viz:position>
+        <viz:position x="141.41547" y="141.41547" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Root CA 2">
@@ -339,43 +339,43 @@
       <node id="CN=DOD SW CA-54,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-54">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-215.21956" y="337.154" z="0.0"></viz:position>
+        <viz:position x="-215.24498" y="337.154" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-60,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-60">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-377.89627" y="-131.19174" z="0.0"></viz:position>
+        <viz:position x="-377.84543" y="-131.19174" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOE SSP CA,OU=Certification Authorities,OU=Department of Energy,O=U.S. Government,C=US" label="DOE SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="200.01112" y="-4.436079E-25" z="0.0"></viz:position>
+        <viz:position x="200.01112" y="2.5420627E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 2,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-137.1683" y="266.8087" z="0.0"></viz:position>
+        <viz:position x="-137.19371" y="266.8087" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 4,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="223.43414" y="200.18916" z="0.0"></viz:position>
+        <viz:position x="223.45956" y="200.21457" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA 2 CA,OU=Eid Passport PIV-I LRA Network,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="271.64078" y="-127.33241" z="0.0"></viz:position>
+        <viz:position x="271.64078" y="-127.345116" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA CA 3,OU=RAPIDGate PIV Interoperable LRA,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-54.497913" y="-294.9875" z="0.0"></viz:position>
+        <viz:position x="-54.491558" y="-294.9875" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Entrust Derived Credential SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Derived Credential SSP CA">
@@ -393,37 +393,37 @@
       <node id="CN=Exostar Federated Identity Service Root CA 2,OU=Certification Authorities,O=Exostar LLC,C=US" label="Exostar Federated Identity Service Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="121.762764" y="-158.68388" z="0.0"></viz:position>
+        <viz:position x="121.762764" y="-158.65846" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Signing CA 3,DC=evincible,DC=com" label="Exostar Federated Identity Service Signing CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.9722" y="2.8152775E-24" z="0.0"></viz:position>
+        <viz:position x="300.02304" y="-2.5240573E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA 2016,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA 2016">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="80.89331" y="58.776875" z="0.0"></viz:position>
+        <viz:position x="80.90601" y="58.776875" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="2.2329883E-24" y="-3.9710836E-24" z="0.0"></viz:position>
+        <viz:position x="2.6862807E-25" y="-2.6461878E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions Intermediate CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-237.44725" y="-183.35307" z="0.0"></viz:position>
+        <viz:position x="-237.47267" y="-183.3785" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions PKI Root CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions PKI Root CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="311.72186" y="390.96838" z="0.0"></viz:position>
+        <viz:position x="311.72186" y="390.91757" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=FTI Certification Authority,OU=FTI PKI Trust Infrastructure,O=Foundation for Trusted Identity,C=US" label="FTI Certification Authority">
@@ -435,13 +435,13 @@
       <node id="CN=HHS-FPKI-Intermediate-CA-E1,OU=Certification Authorities,OU=HHS,O=U.S. Government,C=US" label="HHS-FPKI-Intermediate-CA-E1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-26.107689" y="-198.28175" z="0.0"></viz:position>
+        <viz:position x="-26.104511" y="-198.28175" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ACES CA 2,OU=IdenTrust Public Sector,O=IdenTrust,C=US" label="IdenTrust ACES CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-173.23106" y="99.99285" z="0.0"></viz:position>
+        <viz:position x="-173.20566" y="99.99285" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA 4,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA 4">
@@ -453,19 +453,19 @@
       <node id="CN=IdenTrust ECA 5,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-296.66602" y="-268.28375" z="0.0"></viz:position>
+        <viz:position x="-296.66602" y="-268.33456" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA Component S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA Component S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="400.02225" y="3.7340025E-24" z="0.0"></viz:position>
+        <viz:position x="399.9714" y="-2.9341652E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-296.66602" y="268.28375" z="0.0"></viz:position>
+        <viz:position x="-296.71686" y="268.28375" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22">
@@ -477,7 +477,7 @@
       <node id="CN=IdenTrust ECA S22C,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22C">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-215.21956" y="-337.20483" z="0.0"></viz:position>
+        <viz:position x="-215.24498" y="-337.154" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust Global Common Root CA 1,O=IdenTrust,C=US" label="IdenTrust Global Common Root CA 1">
@@ -489,31 +489,31 @@
       <node id="CN=IdenTrust SAFE-BioPharma CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IdenTrust SAFE-BioPharma CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-280.23682" y="107.16472" z="0.0"></viz:position>
+        <viz:position x="-280.18597" y="107.16472" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-292.80032" y="65.227104" z="0.0"></viz:position>
+        <viz:position x="-292.80032" y="65.239815" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC Server CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC Server CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="287.25613" y="86.4248" z="0.0"></viz:position>
+        <viz:position x="287.30695" y="86.4248" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Leidos FBCA Cloud PKI CA-1,O=Leidos" label="Leidos FBCA Cloud PKI CA-1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-299.26007" y="21.89867" z="0.0"></viz:position>
+        <viz:position x="-299.26007" y="21.901846" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Root Certification Authority 2,OU=Certification Authorities,O=Lockheed Martin Corporation,L=Denver,ST=Colorado,C=US" label="Lockheed Martin Root Certification Authority 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="156.26784" y="256.11444" z="0.0"></viz:position>
+        <viz:position x="156.26784" y="256.0636" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Ministerie van Defensie Certificatie Autoriteit - G2,O=Ministerie van Defensie,C=NL" label="Ministerie van Defensie Certificatie Autoriteit - G2">
@@ -525,7 +525,7 @@
       <node id="CN=Naval Reactors SSP Agency CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="158.68388" y="-121.75005" z="0.0"></viz:position>
+        <viz:position x="158.65846" y="-121.762764" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Device CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Device CA G3">
@@ -537,7 +537,7 @@
       <node id="CN=NextgenIDRootCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NextgenIDRootCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-208.25113" y="215.95709" z="0.0"></viz:position>
+        <viz:position x="-208.22572" y="215.98251" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NGIDTrustCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NGIDTrustCA1">
@@ -549,19 +549,19 @@
       <node id="CN=Northrop Grumman Corporate Root CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Root CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-10.955693" y="-299.76874" z="0.0"></viz:position>
+        <viz:position x="-10.955693" y="-299.81958" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Signing CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Signing CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="368.2321" y="-156.14069" z="0.0"></viz:position>
+        <viz:position x="368.28293" y="-156.16609" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-51.763958" y="-193.16989" z="0.0"></viz:position>
+        <viz:position x="-51.770313" y="-193.16989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G4">
@@ -573,25 +573,25 @@
       <node id="CN=NRC SSP Device CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-141.44089" y="-141.41547" z="0.0"></viz:position>
+        <viz:position x="-141.41547" y="-141.44089" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="184.77728" y="76.5444" z="0.0"></viz:position>
+        <viz:position x="184.80269" y="76.5444" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ACES 4,O=ORC PKI,C=US" label="ORC ACES 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-99.99285" y="-173.20566" z="0.0"></viz:position>
+        <viz:position x="-100.00556" y="-173.23106" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA 6,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.25432" y="350.78564" z="0.0"></viz:position>
+        <viz:position x="192.2289" y="350.78564" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA HW 5,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA HW 5">
@@ -603,19 +603,19 @@
       <node id="CN=ORC ECA SW 5,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA SW 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-66.52415" y="394.47803" z="0.0"></viz:position>
+        <viz:position x="-66.53685" y="394.4272" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC NFI CA 2,O=ORC PKI,C=US" label="ORC NFI CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-141.41547" y="141.41547" z="0.0"></viz:position>
+        <viz:position x="-141.44089" y="141.44089" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC NFI CA 3,O=ORC PKI,C=US" label="ORC NFI CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-100.00556" y="173.23106" z="0.0"></viz:position>
+        <viz:position x="-99.99285" y="173.20566" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
@@ -627,13 +627,13 @@
       <node id="CN=RAPIDGate PIV-I Device CA,O=Eid Passport,Inc.,C=US" label="RAPIDGate PIV-I Device CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="191.89828" y="230.58058" z="0.0"></viz:position>
+        <viz:position x="191.92369" y="230.58058" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=RAPIDGate-Premier CA,O=Eid Passport,Inc.,C=US" label="RAPIDGate-Premier CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-174.55356" y="-243.98332" z="0.0"></viz:position>
+        <viz:position x="-174.57896" y="-243.98332" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=RAPIDGate-Premier Device CA,O=Eid Passport,Inc.,C=US" label="RAPIDGate-Premier Device CA">
@@ -651,55 +651,55 @@
       <node id="CN=SAFE Bridge CA 02,OU=Certification Authorities,O=SAFE-Biopharma,C=US" label="SAFE Bridge CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="76.53169" y="-184.77728" z="0.0"></viz:position>
+        <viz:position x="76.5444" y="-184.77728" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-237.44725" y="183.3785" z="0.0"></viz:position>
+        <viz:position x="-237.44725" y="183.35307" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I Device CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="75.87046" y="290.20627" z="0.0"></viz:position>
+        <viz:position x="75.88316" y="290.20627" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SHA-1 Federal Root CA G2,OU=FPKI,O=U.S. Government,C=US" label="SHA-1 Federal Root CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-30.90165" y="95.10987" z="0.0"></viz:position>
+        <viz:position x="-30.90165" y="95.09716" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=STRAC Bridge Root Certification Authority,OU=STRAC PKI Trust Infrastructure,O=STRAC,C=US" label="STRAC Bridge Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.00556" y="173.20566" z="0.0"></viz:position>
+        <viz:position x="99.99285" y="173.20566" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. CA1,OU=SureID PIV-I,O=SureID,Inc.,C=US" label="SureID Inc. CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-261.6205" y="146.80708" z="0.0"></viz:position>
+        <viz:position x="-261.67136" y="146.8325" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. Device CA2,O=SureID,Inc.,C=US" label="SureID Inc. Device CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-280.23682" y="-107.16472" z="0.0"></viz:position>
+        <viz:position x="-280.18597" y="-107.16472" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec Class 3 SSP Intermediate CA - G3,OU=Symantec Trust Network,O=Symantec Corporation,C=US" label="Symantec Class 3 SSP Intermediate CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="121.762764" y="158.68388" z="0.0"></viz:position>
+        <viz:position x="121.75005" y="158.68388" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-80.89331" y="58.78323" z="0.0"></viz:position>
+        <viz:position x="-80.90601" y="58.776875" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Mobile eIDAS QCA G2,OU=Individual Subscriber CA,O=Trans Sped SRL,C=RO" label="Trans Sped Mobile eIDAS QCA G2">
@@ -723,7 +723,7 @@
       <node id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-193.16989" y="-51.770313" z="0.0"></viz:position>
+        <viz:position x="-193.16989" y="-51.763958" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G4">
@@ -735,7 +735,7 @@
       <node id="CN=U.S. Department of Education Device CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-121.75005" y="158.65846" z="0.0"></viz:position>
+        <viz:position x="-121.762764" y="158.65846" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
@@ -747,25 +747,25 @@
       <node id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-99.99285" y="1.224638E-14" z="0.0"></viz:position>
+        <viz:position x="-100.00556" y="1.22477915E-14" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State PIV CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State PIV CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-173.20566" y="-99.99285" z="0.0"></viz:position>
+        <viz:position x="-173.20566" y="-100.00556" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="193.16989" y="51.763958" z="0.0"></viz:position>
+        <viz:position x="193.16989" y="51.770313" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-193.1953" y="51.763958" z="0.0"></viz:position>
+        <viz:position x="-193.1953" y="51.770313" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G4">
@@ -777,25 +777,25 @@
       <node id="CN=U.S. Department of Transportation Device CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-158.68388" y="-121.75005" z="0.0"></viz:position>
+        <viz:position x="-158.65846" y="-121.75005" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=US DoD CCEB Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="US DoD CCEB Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-450.47964" y="216.97437" z="0.0"></viz:position>
+        <viz:position x="-450.47964" y="216.94894" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=USPTO_INTR_CA1,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=uspto,DC=gov" label="USPTO_INTR_CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.30716" y="26.104511" z="0.0"></viz:position>
+        <viz:position x="198.28175" y="26.104511" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Patient Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Patient Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-299.26007" y="-21.901846" z="0.0"></viz:position>
+        <viz:position x="-299.20923" y="-21.89867" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Provider Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Provider Direct CA 1">
@@ -813,19 +813,19 @@
       <node id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-30.904827" y="-95.09716" z="0.0"></viz:position>
+        <viz:position x="-30.90165" y="-95.10987" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs CA B3,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs CA B3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-76.5444" y="184.77728" z="0.0"></viz:position>
+        <viz:position x="-76.53169" y="184.80269" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs User CA B1,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs User CA B1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="184.80269" y="-76.53169" z="0.0"></viz:position>
+        <viz:position x="184.77728" y="-76.53169" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC ECA 7,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="WidePoint ORC ECA 7">
@@ -837,7 +837,7 @@
       <node id="OU=Department of Veterans Affairs CA,OU=Certification Authorities,OU=Department of Veterans Affairs,O=U.S. Government,C=US" label="Department of Veterans Affairs CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-158.68388" y="121.75005" z="0.0"></viz:position>
+        <viz:position x="-158.65846" y="121.762764" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=DHS CA4,OU=Certification Authorities,OU=Department of Homeland Security,O=U.S. Government,C=US" label="DHS CA4">
@@ -855,7 +855,7 @@
       <node id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="30.904827" y="-95.09716" z="0.0"></viz:position>
+        <viz:position x="30.90165" y="-95.09716" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services SSP CA">
@@ -873,19 +873,19 @@
       <node id="OU=Fiscal Service,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Fiscal Service">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="193.1953" y="-51.763958" z="0.0"></viz:position>
+        <viz:position x="193.16989" y="-51.763958" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO PCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-184.77728" y="76.53169" z="0.0"></viz:position>
+        <viz:position x="-184.80269" y="76.53169" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-54.497913" y="295.03833" z="0.0"></viz:position>
+        <viz:position x="-54.491558" y="295.03833" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=NASA Operational CA,OU=Certification Authorities,OU=NASA,O=U.S. Government,C=US" label="NASA Operational CA">
@@ -897,7 +897,7 @@
       <node id="OU=OCIO CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury OCIO CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-26.104511" y="198.28175" z="0.0"></viz:position>
+        <viz:position x="-26.107689" y="198.30716" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=RaytheonRoot,O=CAs,DC=raytheon,DC=com" label="RaytheonRoot">
@@ -915,19 +915,19 @@
       <node id="OU=U.S. Department of State PIV CA2,OU=Certification Authorities,OU=PIV,OU=Department of State,O=U.S. Government,C=US" label="U.S. Department of State PIV CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="26.107689" y="198.28175" z="0.0"></viz:position>
+        <viz:position x="26.107689" y="198.30716" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Public CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Public CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="51.770313" y="193.1953" z="0.0"></viz:position>
+        <viz:position x="51.763958" y="193.16989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="80.90601" y="-58.78323" z="0.0"></viz:position>
+        <viz:position x="80.89331" y="-58.78323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services NFI Root CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US">
@@ -939,15 +939,11 @@
       <node id="CN=Australian Defence Interoperability CA,OU=CAs,OU=PKI,OU=DoD,O=GOV,C=AU">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="311.72186" y="-390.91757" z="0.0"></viz:position>
+        <viz:position x="311.77267" y="-390.91757" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
     </nodes>
     <edges>
-      <edge id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" source="CN=Air Canada Enterprise Root CA1,OU=Certification Authorities,O=Air Canada,C=CA" target="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
       <edge id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" source="CN=Alexion Pharmaceuticals Issue 2 CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" target="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
@@ -1604,7 +1600,7 @@
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>
-      <edge id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" target="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
+      <edge id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" target="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA" weight="2.0">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>
@@ -1677,10 +1673,6 @@
         <attvalues></attvalues>
       </edge>
       <edge id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" source="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" target="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA" weight="2.0">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=CertiPath Bridge CA,OU=Certification Authorities,O=CertiPath LLC,C=US" source="OU=RaytheonRoot,O=CAs,DC=raytheon,DC=com" target="CN=CertiPath Bridge CA,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>


### PR DESCRIPTION
@lachellel 

Please find the weekly Federal PKI Crawler/Graph update (July 29, 2019 execution):
<br> 

**Live Preview**: https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/fpki-guides/20190729-auto-fpki-graph-update/tools/fpkigraph/
<br>

**Nodes Added or Removed (compared to 07/22/2019 execution):**
- N/A - No change.
<br>

**Edges Added or Removed (compared to 07/22/2019 execution):**
- (E1) REMOVED: CN=Air Canada Enterprise Root CA1,OU=Certification Authorities,O=Air Canada,C=CA ->	CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US
- (E2) ADDED: CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu	-> CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu
- (E3) REMOVED: OU=RaytheonRoot,O=CAs,DC=raytheon,DC=com -> CN=CertiPath Bridge CA,OU=Certification Authorities,O=CertiPath LLC,C=US
<br>

**Root Cause Analysis:** 
- E1: Certificate expired. The expired certificate is still hosted at http://certipath-aia.verisign.com/CertiPathBridgeCA-G2.p7c and http://certipath-aia.symauth.com/CertiPathBridgeCA-G2.p7c. Certificate details:
    - Issuer: CN = Air Canada Enterprise Root CA1, OU = Certification Authorities, O = Air Canada, C = CA
	- Subject: CN = CertiPath Bridge CA - G2, OU = Certification Authorities, O = CertiPath LLC, C = US
	- Serial #: 6D5845CD9072
	- Validity: July 20, 2018, 2:13 p.m. - July 25, 2019, 2:13 p.m.
	- Thumbprint: 4D5519133928FD590FA4D2F36B763373BE083AD6
- E2: This is a repeat of what was seen in #505. The Crawler hit the 169.253.172.92/SIA/CertsIssuedByADRootCA.p7c State AD Root SIA URI, resulting in the "addition" of the most recent U.S. Department of State AD High Assurance CA certificate. Hitting 169.252.24.32/SIA/CertsIssuedByADRootCA.p7c still results in downloading a bundle with 3 certs. See comments in #501 for more detail. State was notified of this issue.
- E3: Certificate expired. The expired certificate is still hosted at http://certipath-aia.verisign.com/CertiPathBridgeRootCA.p7c and http:/​/​certipath-aia.​symauth.​com/​CertiPathBridgeRootCA.​p7c. Certificate details:
    - Issuer: OU = RaytheonRoot, O = CAs, DC = raytheon, DC = com
	- Subject: CN = CertiPath Bridge CA, OU = Certification Authorities, O = CertiPath LLC, C = US
	- Serial #: 465DA78C
	- Validity: June 28, 2018, 10:03 a.m. - July 29, 2019, 3:57 a.m. 
	- Thumbprint: AF2A864118E9E78C85B495BC18BDB03FB842D9AB

**Other Updates:**
- This PR will add four new system notifications:
    - #528 - Entrust re-key event (ou=Entrust Managed Services Root CA, ou=Certification Authorities and o=Entrust, c=US and ou=Entrust Managed Services SSP CA, ou=Certification)
    - #530 - Federal Bridge CA 2016 issuance to DoD (CN = DoD Interoperability Root CA 2, OU = PKI, OU = DoD, O = U.S. Government, C = US), TSCP (CN = TSCP SHA256 Bridge CA, OU = CAs, O = TSCP Inc., C = US), and WidePoint (CN = WidePoint NFI Root 1, OU = Certification Authorities, O = WidePoint, C = US).
    - #473 - Combines notification for two-way cross-cert revocation between Federal Bridge CA 2016 and CT-CSSP-CA-A1 (Federal Bridge CA 2016 -> CT-CSSP-CA-A1) and (CT-CSSP-CA-A1 -> Federal Bridge CA 2016).
- This PR makes a minor update to apple_trust_store_installation.md to prevent build failures resulting from a recent Federalist update. 
- This includes changes originally added to #531 (now closed).
<br>

Please let me know if there are any questions.

Thanks,
Ryan

