### PR TITLE
auto fpki graph update (20200713)

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -2609,6 +2609,13 @@
   sia_uri:  
   ocsp_uri:  http://ssp-ocsp.digicert.com
   
+- notice_date:  July 8, 2020  
+  change_type: OCSP Outage
+  system: Entrust Federal OCSP Service
+  change_description: On July 8, 2020 at approximately 4:00 PM CDT, Entrust Datacard performed a service failover of all Entrust Federal OCSP traffic including ocsp.managed.entrust.com from the Dallas primary site to the Denver alternate site due to ISP routing issues.  The routing issues have been resolved. On Friday, July 10, 2020 at 4:00 PM CDT, all Entrust Federal OCSP traffic including ocsp.managed.entrust.com will fail back to the Dallas primary site. Entrust customers were notified of this issue via email.
+  contact: support at entrustdatacard dot com   
+  ocsp_uri: ocsp.managed.entrust.com, ocspproofs.managed.entrust.com, nfiocsp.managed.entrust.com, doesspocsp.managed.entrust.com, hhspkiocsp.managed.entrust.com, feddcsocsp.managed.entrust.com
+  
 #- notice_date:  
 #  change_type: CA Certificate Issuance
 #  start_datetime:

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -2609,10 +2609,10 @@
   sia_uri:  
   ocsp_uri:  http://ssp-ocsp.digicert.com
   
-- notice_date:  July 8, 2020  
+- notice_date: July 10, 2020  
   change_type: OCSP Outage
   system: Entrust Federal OCSP Service
-  change_description: On July 8, 2020 at approximately 4:00 PM CDT, Entrust Datacard performed a service failover of all Entrust Federal OCSP traffic including ocsp.managed.entrust.com from the Dallas primary site to the Denver alternate site due to ISP routing issues.  The routing issues have been resolved. On Friday, July 10, 2020 at 4:00 PM CDT, all Entrust Federal OCSP traffic including ocsp.managed.entrust.com will fail back to the Dallas primary site. Entrust customers were notified of this issue via email.
+  change_description: On July 8, 2020 at approximately 4:00 PM CDT, Entrust Datacard performed a service failover of all Entrust Federal OCSP traffic including ocsp.managed.entrust.com from the Dallas primary site to the Denver alternate site due to ISP routing issues.  On Friday, July 10, 2020 at 4:00 PM CDT, all Entrust Federal OCSP traffic including ocsp.managed.entrust.com failed back to the Dallas primary site. Entrust customers were notified of this issue via email.
   contact: support at entrustdatacard dot com   
   ocsp_uri: ocsp.managed.entrust.com, ocspproofs.managed.entrust.com, nfiocsp.managed.entrust.com, doesspocsp.managed.entrust.com, hhspkiocsp.managed.entrust.com, feddcsocsp.managed.entrust.com
   

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -2612,7 +2612,7 @@
 - notice_date: July 10, 2020  
   change_type: OCSP Outage
   system: Entrust Federal OCSP Service
-  change_description: On July 8, 2020 at approximately 4:00 PM CDT, Entrust Datacard performed a service failover of all Entrust Federal OCSP traffic including ocsp.managed.entrust.com from the Dallas primary site to the Denver alternate site due to ISP routing issues.  On Friday, July 10, 2020 at 4:00 PM CDT, all Entrust Federal OCSP traffic including ocsp.managed.entrust.com failed back to the Dallas primary site. Entrust customers were notified of this issue via email.
+  change_description: On July 8, 2020 at approximately 4:00 PM CDT, Entrust Datacard performed a service failover of all Entrust Federal OCSP traffic including ocsp.managed.entrust.com from the Dallas primary site to the Denver alternate site due to ISP routing issues.  On Friday, July 10, 2020 at 4:00 PM CDT, all Entrust Federal OCSP traffic failed back to the Dallas primary site. Entrust customers were notified of this issue via email.
   contact: support at entrustdatacard dot com   
   ocsp_uri: ocsp.managed.entrust.com, ocspproofs.managed.entrust.com, nfiocsp.managed.entrust.com, doesspocsp.managed.entrust.com, hhspkiocsp.managed.entrust.com, feddcsocsp.managed.entrust.com
   

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -4,7 +4,7 @@ title: Federal PKI Graph
 collection: tools
 permalink: tools/fpkigraph/
 ---
-**Last Update**: July 07, 2020
+**Last Update**: July 13, 2020
 {% include graph.html %}
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  

--- a/_tools/fpki-certs.gexf
+++ b/_tools/fpki-certs.gexf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
-  <meta lastmodifieddate="2020-07-07">
+  <meta lastmodifieddate="2020-07-13">
     <creator>Gephi 0.8.1</creator>
     <description></description>
   </meta>
@@ -9,319 +9,319 @@
       <node id="CN=Alexion Pharmaceuticals Issue 2 CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" label="Alexion Pharmaceuticals Issue 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="164.10092" y="251.15518" z="0.0"></viz:position>
+        <viz:position x="263.80768" y="-142.7888" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" label="Boeing PCA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="263.85852" y="-142.81422" z="0.0"></viz:position>
+        <viz:position x="164.07552" y="251.15518" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton Device CA 02,OU=Certification Authorities,O=Booz Allen Hamilton,C=US" label="Booz Allen Hamilton Device CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="73.64515" y="290.86746" z="0.0"></viz:position>
+        <viz:position x="73.64515" y="-290.81662" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton PIVi CA 01,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="Booz Allen Hamilton PIVi CA 01">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.90305" y="-49.379696" z="0.0"></viz:position>
+        <viz:position x="-203.21558" y="-220.7129" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Bureau of the Census Agency CA,OU=Department of Commerce,O=U.S. Government,C=US" label="Bureau of the Census Agency CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="40.68826" y="-195.81483" z="0.0"></viz:position>
+        <viz:position x="183.42937" y="79.68527" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-24.772503" y="-298.95493" z="0.0"></viz:position>
+        <viz:position x="236.76057" y="-184.26863" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA2,OU=Certificate Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="203.19016" y="-220.7129" z="0.0"></viz:position>
+        <viz:position x="283.7465" y="-97.41149" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 2,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="24.775679" y="-298.95493" z="0.0"></viz:position>
+        <viz:position x="-236.76057" y="184.26863" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.58495" y="53.95748" z="0.0"></viz:position>
+        <viz:position x="-13.64991" y="-199.52792" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="92.01987" y="-177.57999" z="0.0"></viz:position>
+        <viz:position x="-183.42937" y="-79.67256" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Class 3 SSP Intermediate CA - G4,O=DigiCert,Inc.,C=US" label="DigiCert Class 3 SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="155.1234" y="-126.213394" z="0.0"></viz:position>
+        <viz:position x="199.9857" y="2.5729099E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="99.99285" y="1.9721183E-24" z="0.0"></viz:position>
+        <viz:position x="100.00556" y="1.3351711E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federated ID L3 CA,OU=www.digicert.com,O=DigiCert Inc,C=US" label="DigiCert Federated ID L3 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-115.34115" y="-163.38884" z="0.0"></viz:position>
+        <viz:position x="-198.15457" y="27.233063" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="178.29208" y="-358.05923" z="0.0"></viz:position>
+        <viz:position x="-109.479034" y="384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-399.9714" y="4.043077E-13" z="0.0"></viz:position>
+        <viz:position x="-178.31749" y="358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-372.96246" y="-144.49275" z="0.0"></viz:position>
+        <viz:position x="241.05862" y="-319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="340.05325" y="-210.5909" z="0.0"></viz:position>
+        <viz:position x="109.466324" y="384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-178.29208" y="358.05923" z="0.0"></viz:position>
+        <viz:position x="109.466324" y="-384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-241.05862" y="319.1989" z="0.0"></viz:position>
+        <viz:position x="-241.08403" y="319.24973" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.05862" y="-319.1989" z="0.0"></viz:position>
+        <viz:position x="372.96246" y="144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="36.905228" y="398.34372" z="0.0"></viz:position>
+        <viz:position x="-340.1041" y="210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="109.479034" y="-384.71213" z="0.0"></viz:position>
+        <viz:position x="-373.0133" y="144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.59787" y="269.4536" z="0.0"></viz:position>
+        <viz:position x="-340.05325" y="-210.5909" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="393.15558" y="73.505264" z="0.0"></viz:position>
+        <viz:position x="-393.15558" y="73.505264" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-340.05325" y="210.5909" z="0.0"></viz:position>
+        <viz:position x="340.05325" y="210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-372.96246" y="144.51817" z="0.0"></viz:position>
+        <viz:position x="-295.6487" y="-269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-340.05325" y="-210.5909" z="0.0"></viz:position>
+        <viz:position x="295.59787" y="-269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-393.15558" y="73.505264" z="0.0"></viz:position>
+        <viz:position x="-178.29208" y="-358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="372.96246" y="144.51817" z="0.0"></viz:position>
+        <viz:position x="295.59787" y="269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.59787" y="-269.4536" z="0.0"></viz:position>
+        <viz:position x="-241.05862" y="-319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.59787" y="-269.4536" z="0.0"></viz:position>
+        <viz:position x="178.29208" y="358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-37,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-37">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-178.31749" y="-358.05923" z="0.0"></viz:position>
+        <viz:position x="36.905228" y="398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-38,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-38">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="340.05325" y="210.5909" z="0.0"></viz:position>
+        <viz:position x="241.05862" y="319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-45,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-45">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-241.08403" y="-319.1989" z="0.0"></viz:position>
+        <viz:position x="-36.905228" y="398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-46,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-46">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="109.466324" y="384.71213" z="0.0"></viz:position>
+        <viz:position x="-393.15558" y="-73.49255" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="170.89131" y="103.9094" z="0.0"></viz:position>
+        <viz:position x="92.01987" y="-177.6054" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Root CA 3,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Root CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.90305" y="49.38605" z="0.0"></viz:position>
+        <viz:position x="-299.9722" y="3.6737025E-14" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-53,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-53">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-36.911583" y="398.29288" z="0.0"></viz:position>
+        <viz:position x="-109.479034" y="-384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-54,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-54">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.59787" y="269.4536" z="0.0"></viz:position>
+        <viz:position x="393.15558" y="73.505264" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-60,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-60">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.466324" y="384.71213" z="0.0"></viz:position>
+        <viz:position x="36.905228" y="-398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOE SSP CA,OU=Certification Authorities,OU=Department of Energy,O=U.S. Government,C=US" label="DOE SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="183.42937" y="-79.67256" z="0.0"></viz:position>
+        <viz:position x="92.01987" y="177.6054" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 4,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-203.21558" y="-220.7129" z="0.0"></viz:position>
+        <viz:position x="-263.80768" y="142.81422" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA 2 CA,OU=Eid Passport PIV-I LRA Network,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="120.503876" y="274.69266" z="0.0"></viz:position>
+        <viz:position x="-120.503876" y="-274.69266" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA CA 3,OU=RAPIDGate PIV Interoperable LRA,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-283.7465" y="-97.41149" z="0.0"></viz:position>
+        <viz:position x="24.775679" y="298.95493" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Entrust Derived Credential SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Derived Credential SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-199.9857" y="2.0215385E-13" z="0.0"></viz:position>
+        <viz:position x="136.50706" y="146.1967" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Digital Certificate Service Signing CA 1,O=Exostar UK Limited,C=GB" label="Exostar Digital Certificate Service Signing CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-73.64515" y="290.86746" z="0.0"></viz:position>
+        <viz:position x="-263.80768" y="-142.7888" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Root CA 2,OU=Certification Authorities,O=Exostar LLC,C=US" label="Exostar Federated Identity Service Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-13.64991" y="199.55334" z="0.0"></viz:position>
+        <viz:position x="155.1234" y="-126.213394" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Signing CA 3,DC=evincible,DC=com" label="Exostar Federated Identity Service Signing CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="236.76057" y="184.26863" z="0.0"></viz:position>
+        <viz:position x="164.07552" y="-251.1806" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA 2016,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA 2016">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="76.595276" y="64.2734" z="0.0"></viz:position>
+        <viz:position x="76.60799" y="64.28611" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA G4,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="17.362213" y="98.47964" z="0.0"></viz:position>
+        <viz:position x="17.368565" y="98.47964" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-3.4598177E-24" y="-1.7154567E-25" z="0.0"></viz:position>
+        <viz:position x="-1.4704287E-24" y="1.0247774E-25" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions Intermediate CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-263.80768" y="142.7888" z="0.0"></viz:position>
+        <viz:position x="24.772503" y="-298.95493" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions PKI Root CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions PKI Root CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="499.9706" y="1.8892743E-24" z="0.0"></viz:position>
+        <viz:position x="499.9706" y="1.8629832E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=FTI Certification Authority,OU=FTI PKI Trust Infrastructure,O=Foundation for Trusted Identity,C=US" label="FTI Certification Authority">
@@ -333,97 +333,97 @@
       <node id="CN=HHS-FPKI-Intermediate-CA-E1,OU=Certification Authorities,OU=HHS,O=U.S. Government,C=US" label="HHS-FPKI-Intermediate-CA-E1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-183.42937" y="79.67256" z="0.0"></viz:position>
+        <viz:position x="-115.32844" y="163.38884" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ACES CA 2,OU=IdenTrust Public Sector,O=IdenTrust,C=US" label="IdenTrust ACES CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.15457" y="-27.233063" z="0.0"></viz:position>
+        <viz:position x="-92.00716" y="-177.57999" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA Component S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA Component S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-393.15558" y="-73.49255" z="0.0"></viz:position>
+        <viz:position x="393.15558" y="-73.505264" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.479034" y="-384.76294" z="0.0"></viz:position>
+        <viz:position x="-36.905228" y="-398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="399.9714" y="-6.9398406E-25" z="0.0"></viz:position>
+        <viz:position x="178.29208" y="-358.11005" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22C,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22C">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="36.911583" y="-398.29288" z="0.0"></viz:position>
+        <viz:position x="-399.9714" y="4.0426256E-13" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust Global Common Root CA 1,O=IdenTrust,C=US" label="IdenTrust Global Common Root CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.58495" y="-53.963837" z="0.0"></viz:position>
+        <viz:position x="170.86589" y="103.9094" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust SAFE-BioPharma CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IdenTrust SAFE-BioPharma CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="203.19016" y="220.73833" z="0.0"></viz:position>
+        <viz:position x="-164.10092" y="-251.15518" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-236.76057" y="-184.29405" z="0.0"></viz:position>
+        <viz:position x="203.19016" y="220.7129" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC Server CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC Server CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-24.772503" y="298.95493" z="0.0"></viz:position>
+        <viz:position x="-283.7465" y="97.41149" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Leidos FBCA Cloud PKI CA-1,O=Leidos" label="Leidos FBCA Cloud PKI CA-1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-120.503876" y="274.74347" z="0.0"></viz:position>
+        <viz:position x="120.51659" y="-274.69266" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Certification Authority 4 G2,OU=Certification Authorities,O=Lockheed Martin Corporation,C=US" label="Lockheed Martin Certification Authority 4 G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="178.29208" y="358.05923" z="0.0"></viz:position>
+        <viz:position x="-295.59787" y="269.50446" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Root Certification Authority 2,OU=Certification Authorities,O=Lockheed Martin Corporation,L=Denver,ST=Colorado,C=US" label="Lockheed Martin Root Certification Authority 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-164.07552" y="-251.1806" z="0.0"></viz:position>
+        <viz:position x="236.73515" y="184.26863" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3,OID.2.5.4.97=NTRNL-27370985,O=Ministerie van Defensie,C=NL" label="Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="24.772503" y="298.95493" z="0.0"></viz:position>
+        <viz:position x="-24.772503" y="-298.95493" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Agency CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="66.96921" y="-188.43951" z="0.0"></viz:position>
+        <viz:position x="-115.32844" y="-163.41426" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Device CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.12915" y="27.233063" z="0.0"></viz:position>
+        <viz:position x="-66.96921" y="188.46492" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NextgenIDRootCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NextgenIDRootCA1">
@@ -435,133 +435,133 @@
       <node id="CN=NGIDTrustCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NGIDTrustCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-36.905228" y="-398.29288" z="0.0"></viz:position>
+        <viz:position x="399.9714" y="-1.4979544E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Root CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Root CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="283.79733" y="97.424194" z="0.0"></viz:position>
+        <viz:position x="-120.503876" y="274.69266" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Signing CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Signing CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="372.96246" y="-144.49275" z="0.0"></viz:position>
+        <viz:position x="340.05325" y="-210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-40.694614" y="195.81483" z="0.0"></viz:position>
+        <viz:position x="40.68826" y="-195.81483" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="115.32844" y="-163.41426" z="0.0"></viz:position>
+        <viz:position x="-183.45479" y="79.67256" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="136.53247" y="-146.17128" z="0.0"></viz:position>
+        <viz:position x="66.98192" y="-188.46492" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-92.00716" y="177.57999" z="0.0"></viz:position>
+        <viz:position x="-192.61037" y="-53.95748" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA 6,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.05862" y="319.1989" z="0.0"></viz:position>
+        <viz:position x="-372.96246" y="-144.51817" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC NFI CA 3,O=ORC PKI,C=US" label="ORC NFI CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-236.76057" y="184.29405" z="0.0"></viz:position>
+        <viz:position x="73.64515" y="290.81662" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-49.996426" y="86.60283" z="0.0"></viz:position>
+        <viz:position x="-50.00278" y="86.61553" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=RAPIDGate-Premier CA,O=Eid Passport,Inc.,C=US" label="RAPIDGate-Premier CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.9539" y="49.38605" z="0.0"></viz:position>
+        <viz:position x="-164.07552" y="251.15518" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=RAPIDGate-Premier Device CA,O=Eid Passport,Inc.,C=US" label="RAPIDGate-Premier Device CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-300.02304" y="3.6737025E-14" z="0.0"></viz:position>
+        <viz:position x="295.90305" y="49.38605" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Class 3 MASCA,OU=Class3-g2,O=cas,DC=raytheon,DC=com" label="Raytheon Class 3 MASCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-120.51659" y="-274.69266" z="0.0"></viz:position>
+        <viz:position x="203.19016" y="-220.7129" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SAFE Bridge CA 02,OU=Certification Authorities,O=SAFE-Biopharma,C=US" label="SAFE Bridge CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.58495" y="-53.95748" z="0.0"></viz:position>
+        <viz:position x="66.98192" y="188.43951" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-283.7465" y="97.41149" z="0.0"></viz:position>
+        <viz:position x="-73.64515" y="-290.81662" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I Device CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-263.80768" y="-142.7888" z="0.0"></viz:position>
+        <viz:position x="-295.90305" y="-49.38605" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=STRAC Bridge Root Certification Authority,OU=STRAC PKI Trust Infrastructure,O=STRAC,C=US" label="STRAC Bridge Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.58495" y="53.963837" z="0.0"></viz:position>
+        <viz:position x="-13.64991" y="199.52792" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. CA1,OU=SureID PIV-I,O=SureID,Inc.,C=US" label="SureID Inc. CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="120.51659" y="-274.69266" z="0.0"></viz:position>
+        <viz:position x="-236.73515" y="-184.26863" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. Device CA2,O=SureID,Inc.,C=US" label="SureID Inc. Device CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="236.76057" y="-184.26863" z="0.0"></viz:position>
+        <viz:position x="-24.775679" y="298.95493" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec Class 3 SSP Intermediate CA - G3,OU=Symantec Trust Network,O=Symantec Corporation,C=US" label="Symantec Class 3 SSP Intermediate CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-66.96921" y="-188.43951" z="0.0"></viz:position>
+        <viz:position x="198.12915" y="-27.23624" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.96543" y="34.209415" z="0.0"></viz:position>
+        <viz:position x="-93.97814" y="34.20306" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Mobile eIDAS QCA G2,OU=Individual Subscriber CA,O=Trans Sped SRL,C=RO" label="Trans Sped Mobile eIDAS QCA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-73.65785" y="-290.86746" z="0.0"></viz:position>
+        <viz:position x="-73.64515" y="290.86746" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Root CA G2,OU=Trans Sped CA,O=Trans Sped SRL,C=RO" label="Trans Sped Root CA G2">
@@ -573,67 +573,67 @@
       <node id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-170.86589" y="103.9094" z="0.0"></viz:position>
+        <viz:position x="192.58495" y="-53.963837" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="92.00716" y="177.6054" z="0.0"></viz:position>
+        <viz:position x="198.15457" y="27.233063" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-155.1234" y="-126.226105" z="0.0"></viz:position>
+        <viz:position x="40.694614" y="195.84024" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="13.64991" y="199.52792" z="0.0"></viz:position>
+        <viz:position x="-40.68826" y="195.84024" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="40.68826" y="195.81483" z="0.0"></viz:position>
+        <viz:position x="115.34115" y="-163.41426" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-155.1488" y="126.226105" z="0.0"></viz:position>
+        <viz:position x="13.648321" y="199.52792" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.96543" y="-34.20306" z="0.0"></viz:position>
+        <viz:position x="-93.96543" y="-34.209415" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="170.89131" y="-103.9094" z="0.0"></viz:position>
+        <viz:position x="136.50706" y="-146.17128" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="13.64991" y="-199.55334" z="0.0"></viz:position>
+        <viz:position x="-92.00716" y="177.57999" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-183.45479" y="-79.67256" z="0.0"></viz:position>
+        <viz:position x="115.32844" y="163.38884" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-13.648321" y="-199.52792" z="0.0"></viz:position>
+        <viz:position x="-136.50706" y="-146.1967" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=US DoD CCEB Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="US DoD CCEB Interoperability Root CA 2">
@@ -645,19 +645,19 @@
       <node id="CN=USPTO_INTR_CA1,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=uspto,DC=gov" label="USPTO_INTR_CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="183.42937" y="79.68527" z="0.0"></viz:position>
+        <viz:position x="192.58495" y="53.963837" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Patient Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Patient Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.90305" y="-49.38605" z="0.0"></viz:position>
+        <viz:position x="283.7465" y="97.424194" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Provider Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Provider Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.9722" y="3.361285E-24" z="0.0"></viz:position>
+        <viz:position x="-295.90305" y="49.379696" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
@@ -669,121 +669,121 @@
       <node id="CN=Veterans Affairs CA B3,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs CA B3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="136.53247" y="146.17128" z="0.0"></viz:position>
+        <viz:position x="-170.86589" y="-103.92211" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs User CA B1,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs User CA B1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-115.32844" y="163.38884" z="0.0"></viz:position>
+        <viz:position x="-155.1488" y="126.213394" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI CA 5,O=ORC PKI,C=US" label="WidePoint NFI CA 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-164.07552" y="251.15518" z="0.0"></viz:position>
+        <viz:position x="120.503876" y="274.69266" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint NFI Root 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-136.50706" y="-146.17128" z="0.0"></viz:position>
+        <viz:position x="-66.96921" y="-188.46492" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC ECA 7,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="WidePoint ORC ECA 7">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="393.15558" y="-73.49255" z="0.0"></viz:position>
+        <viz:position x="372.96246" y="-144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint ORC NFI 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="164.07552" y="-251.15518" z="0.0"></viz:position>
+        <viz:position x="-283.7465" y="-97.41149" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Department of Veterans Affairs CA,OU=Certification Authorities,OU=Department of Veterans Affairs,O=U.S. Government,C=US" label="Department of Veterans Affairs CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-198.12915" y="-27.233063" z="0.0"></viz:position>
+        <viz:position x="-200.01112" y="2.0215385E-13" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=DHS CA4,OU=Certification Authorities,OU=Department of Homeland Security,O=U.S. Government,C=US" label="DHS CA4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-136.53247" y="146.17128" z="0.0"></viz:position>
+        <viz:position x="-192.58495" y="53.963837" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services NFI Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services NFI Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-66.96921" y="188.46492" z="0.0"></viz:position>
+        <viz:position x="-170.86589" y="103.92211" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="17.362213" y="-98.49235" z="0.0"></viz:position>
+        <viz:position x="17.362213" y="-98.47964" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="155.1488" y="126.226105" z="0.0"></viz:position>
+        <viz:position x="183.42937" y="-79.67256" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust NFI Medium Assurance SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust NFI Medium Assurance SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="283.79733" y="-97.41149" z="0.0"></viz:position>
+        <viz:position x="295.90305" y="-49.379696" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Fiscal Service,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Fiscal Service">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-40.694614" y="-195.81483" z="0.0"></viz:position>
+        <viz:position x="155.1234" y="126.226105" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO PCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="199.9857" y="-1.7570356E-24" z="0.0"></viz:position>
+        <viz:position x="13.64991" y="-199.52792" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="73.64515" y="-290.81662" z="0.0"></viz:position>
+        <viz:position x="299.9722" y="2.6730096E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=NASA Operational CA,OU=Certification Authorities,OU=NASA,O=U.S. Government,C=US" label="NASA Operational CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-170.86589" y="-103.9094" z="0.0"></viz:position>
+        <viz:position x="-198.12915" y="-27.233063" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=OCIO CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury OCIO CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-92.01987" y="-177.57999" z="0.0"></viz:position>
+        <viz:position x="-136.53247" y="146.17128" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Social Security Administration Certification Authority,OU=SSA,O=U.S. Government,C=US" label="Social Security Administration Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="115.32844" y="163.41426" z="0.0"></viz:position>
+        <viz:position x="-40.694614" y="-195.81483" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=U.S. Department of State PIV CA2,OU=Certification Authorities,OU=PIV,OU=Department of State,O=U.S. Government,C=US" label="U.S. Department of State PIV CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="66.96921" y="188.43951" z="0.0"></viz:position>
+        <viz:position x="170.86589" y="-103.92211" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Public CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Public CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-198.15457" y="27.233063" z="0.0"></viz:position>
+        <viz:position x="-155.1234" y="-126.213394" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA">
@@ -807,7 +807,7 @@
       <node id="CN=CertiPath Common Policy Root Certification Authority - G2,OU=Certification Authorities,O=CertiPath LLC,C=US">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-353.58313" y="-353.5323" z="0.0"></viz:position>
+        <viz:position x="-353.5323" y="-353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com">
@@ -819,12 +819,16 @@
       <node id="CN=Australian Defence Interoperability CA,OU=CAs,OU=PKI,OU=DoD,O=GOV,C=AU">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="353.58313" y="-353.5323" z="0.0"></viz:position>
+        <viz:position x="353.5323" y="-353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
     </nodes>
     <edges>
       <edge id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" source="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" target="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" source="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" target="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>


### PR DESCRIPTION
@lachellel

Please find the weekly Federal PKI Crawler/Graph update (July 13, 2020 execution).

<br>

**Live Preview:** https://federalist-2147738e-703c-4833-9101-89d779f09ce1.app.cloud.gov/preview/gsa/fpki-guides/20200713-auto-fpki-graph-update/tools/fpkigraph/

<br>

**Nodes Added or Removed (compared to July 7, 2020 execution):**
- No change.


<br>

**Edges Added or Removed (compared to July 7, 2020 execution):**
- E1 (ADDED): CN=Boeing PCA G3, OU=certservers, O=Boeing, C=US -> CN=CertiPath Bridge CA - G3, OU=Certification Authorities, O=CertiPath, C=US


<br>

**Root Cause Analysis:**
- E1: New certificate detected. Certificate details:
     - Subject: CN=CertiPath Bridge CA - G3, OU=Certification Authorities, O=CertiPath, C=US
	 - Issuer: CN=Boeing PCA G3, OU=certservers, O=Boeing, C=US
	 - Validity: July 9, 2020 to August 9, 2021
	 - Serial #: 61afb3e6000000000015 
	 - Thumbprint (SHA-1 hash): 18c918212e8beccd6ca938f6be1ee73a993dae9b
	 - Key size: 4096-bit (RSA)
	 - Signing Algorithm: SHA-256 with RSA
	 - Note: This certificate does not validate to the Federal Common Policy CA. 


<br>

**Other updates:**
- Added System Notification for the Entrust OCSP Outage (#717).

<br>

Please let me know if you have any questions.

Thanks,
Ryan



