### PR TITLE
auto fpki graph update (20210209)

### DIFF
--- a/_common/00_index.md
+++ b/_common/00_index.md
@@ -35,7 +35,7 @@ This change affects *all federal agencies* and the following services:
    <li value="8"><a href="https://fpki.idmanagement.gov/common/verify-migration/">Verify migration to the Federal Common Policy CA G2</a></li>
 </ol>
 
-{% include alert-info.html content="We are collaborating with CISA on a series of webinars to communicate the upcoming changes and answer your questions.  Email fpkirootupdate@gsa.gov to be notified of our next webinar." %} 
+{% include alert-info.html content="We are collaborating with CISA on a series of webinars to communicate the upcoming changes and answer your questions.  The next webinar is scheduled for February 17, 2021, at 1PM ET.  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions." %} 
 
 ## Need Help?
 

--- a/_common/00_index.md
+++ b/_common/00_index.md
@@ -25,7 +25,7 @@ This change affects *all federal agencies* and the following services:
    <li><a href="https://fpki.idmanagement.gov/common/distribute-os/">Distribute the certificate to operating systems</a></li>
    <li><a href="https://fpki.idmanagement.gov/common/verify-os-distribution/">Verify operating system distribution</a></li>
    <li><a href="https://fpki.idmanagement.gov/common/distribute-apps/">Distribute the certificate to applications</a></li>
-   <li><a href="https://fpki.idmanagement.gov/common/certificates/">Distribute the CA certificates issued by the Federal Common Policy CA G2 (optional)</a></li>
+   <li><a href="https://fpki.idmanagement.gov/common/certificates/">Determine if you need to distribute the CA certificates issued by the Federal Common Policy CA G2</a></li>
 </ol>
     
 **Recommended steps to complete by April 20th, 2021:**

--- a/_common/00_index.md
+++ b/_common/00_index.md
@@ -35,7 +35,7 @@ This change affects *all federal agencies* and the following services:
    <li value="8"><a href="https://fpki.idmanagement.gov/common/verify-migration/">Verify migration to the Federal Common Policy CA G2</a></li>
 </ol>
 
-{% include alert-info.html content="We are collaborating with CISA on a series of webinars to communicate the upcoming changes and answer your questions.  The next webinar is scheduled for February 17, 2021, at 1PM ET.  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions." %} 
+{% include alert-info.html content="We are collaborating with CISA on a series of webinars to communicate the upcoming changes and answer your questions.  <b>The next webinar is scheduled for February 17, 2021, at 1PM ET</b>.  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions." %} 
 
 ## Need Help?
 

--- a/_common/01_prepare_to_migrate.md
+++ b/_common/01_prepare_to_migrate.md
@@ -103,7 +103,7 @@ We encourage agency staff to participate in steps where their roles appear in bl
 <tr>
   <td colspan="7" class="desc">
   <ul>
-	<li>Work with your colleagues to develop, execute, and test a plan to distribute the FCPCA G2 certificate (and, optionally, the CA certificates issued by the FCPCA G2) to operating systems and applications across your enterprise.</li>
+	<li>Work with your colleagues to develop, execute, and test a plan to distribute the FCPCA G2 certificate (and, possibly, the CA certificates issued by the FCPCA G2) to operating systems and applications across your enterprise.</li>
 	<li>Communication is key! Collaborate with both colleagues and stakeholders across your agency.</li> 
   </ul>
   </td>

--- a/_common/01_prepare_to_migrate.md
+++ b/_common/01_prepare_to_migrate.md
@@ -46,7 +46,7 @@ We encourage agency staff to participate in steps where their roles appear in bl
   <td colspan="7" class="desc">
   <ul>
 	<li>We are collaborating with CISA on a series of webinars to communicate upcoming changes and answer your questions. </li>
-	<li><strong>We're planning our next webinar!</strong> E-mail fpkirootupdate@gsa.gov to join our e-mail distribution, and we'll follow-up once more information is available.</li>
+	<li><strong>The next webinar is scheduled for February 17, 2021, at 1PM ET.  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions.</li>
 	<li>We encourage any relevant stakeholders in your organization to participate in the webinar.</li>
   </ul>
   </td>

--- a/_common/01_prepare_to_migrate.md
+++ b/_common/01_prepare_to_migrate.md
@@ -46,7 +46,7 @@ We encourage agency staff to participate in steps where their roles appear in bl
   <td colspan="7" class="desc">
   <ul>
 	<li>We are collaborating with CISA on a series of webinars to communicate upcoming changes and answer your questions. </li>
-	<li><strong>The next webinar is scheduled for February 17, 2021, at 1PM ET.  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions.</li>
+	<li><strong>The next webinar is scheduled for February 17, 2021, at 1PM ET.</strong>  Email fpkirootupdate@gsa.gov for more details, or to join our distribution so you're automatically notified of future sessions.</li>
 	<li>We encourage any relevant stakeholders in your organization to participate in the webinar.</li>
   </ul>
   </td>

--- a/_common/03_distribute_os.md
+++ b/_common/03_distribute_os.md
@@ -29,7 +29,7 @@ To distribute the Federal Common Policy CA G2 (FCPCA G2) certificate, use one of
 - [Use the command line](#linux-and-unix-solutions)
 
 
-{% include alert-warning.html content="<strong>Important!</strong> If your enterprise systems do not have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled, you may also need to distribute the <a href=\"../certificates\">intermediate CA certificates</a> issued by the FCPCA G2." %}
+{% include alert-warning.html content="<strong>Important!</strong> If your enterprise systems do not have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled, you also need to distribute the relevant <a href=\"../certificates\">intermediate CA certificates</a> issued by the FCPCA G2." %}
 
 <br>
 

--- a/_common/03_distribute_os.md
+++ b/_common/03_distribute_os.md
@@ -26,7 +26,7 @@ To distribute the Federal Common Policy CA G2 (FCPCA G2) certificate, use one of
 - [Enable Full Trust for FCPCA G2](#enable-full-trust-for-fcpca-g2)
 
 ## Linux/Unix Solutions
-- [Use the command line](#use-the-command-line)
+- [Use the command line](#linux-and-unix-solutions)
 
 
 {% include alert-warning.html content="<strong>Important!</strong> If your enterprise systems do not have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled, you may also need to distribute the <a href=\"../certificates\">intermediate CA certificates</a> issued by the FCPCA G2." %}
@@ -378,11 +378,14 @@ This option works for **iOS** devices only.
 ---------------------------------------------------
 
 
-## Linux/Unix Solutions
+## Linux and Unix Solutions
+
+### Debian-based kernels
 
 1. Launch the command line.
 
 1. Change directory with the following command:
+
     ```
         cd /usr/local/share/ca-certificates/
     ```
@@ -395,6 +398,7 @@ This option works for **iOS** devices only.
     ```
 
 1. Update Trusted Certificates with the following command:
+
     ```
         sudo update-ca-certificates
     ```
@@ -402,6 +406,32 @@ This option works for **iOS** devices only.
 
 <br>
 
+
+### Red Hat Enterprise Linux, CentOS, and other non-Debian-based kernels
+
+1. Launch the command line.
+
+1. Change directory with the following command:
+
+    ```
+        cd /etc/pki/ca-trust/anchors
+    ```
+
+1. Copy your verified copy of FCPCA G2 into the folder and set permissions with the following commands:
+
+    ```
+        sudo cp [PATH\]fcpcag2.crt .
+        sudo chown root.root fcpcag2.crt
+        sudo chmod 644 fcpcag2.crt
+    ```
+
+1. Update Trusted Certificates with the following command:
+
+    ```
+        sudo /bin/update-ca-trust extract
+    ```
+
+<br>
 
 
 Next, [verify distribution of the FCPCA G2 certificate as an operating system trusted root]({{site.baseurl}}/common/verify-os-distribution/).

--- a/_common/05_distribute_applications.md
+++ b/_common/05_distribute_applications.md
@@ -21,4 +21,4 @@ Collaborate across agency teams to identify applications that rely on custom tru
 
 <br>
 
-Optionally, [distribute the CA certificates issued by the FCPCA G2]({{site.baseurl}}/common/certificates/).
+Next, determine if you need to [distribute the CA certificates issued by the FCPCA G2]({{site.baseurl}}/common/certificates/).

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -149,7 +149,7 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
 
-{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"https://fpki.idmanagement.gov/common/faq/#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in the <a href=\"../faq\">FAQ</a>." %}
 
 
 #### Issued to: Verizon SSP CA A2

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -6,7 +6,7 @@ permalink: common/certificates/
 ---
 
 
-{% include alert-warning.html content="Important! If your enterprise systems do not have <a href="https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target="_blank">dynamic path validation enabled, you'll need to manually distribute the relevant <a href="../certificates">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
+{% include alert-warning.html content="Important! If your enterprise systems <b>do not</b> have <a href="https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target="_blank">dynamic path validation enabled, you'll need to manually distribute the relevant <a href="../certificates">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
 	
 For systems using dynamic path validation, you can *optionally* distribute the CA certificates [issued by the Federal Common Policy CA (FCPCA) G2](#certificates-issued-by-the-federal-common-policy-ca-g2) to simplify path building. Sample procedures for the distribution of intermediate CA certificates are below:
 

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -6,7 +6,7 @@ permalink: common/certificates/
 ---
 
 
-{% include alert-warning.html content="Important! If your enterprise systems <b>do not</b> have <a href="https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target="_blank">dynamic path validation enabled, you'll need to manually distribute the relevant <a href="../certificates">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
+{% include alert-warning.html content="Important! If your enterprise systems <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation enabled, you'll need to manually distribute the relevant <a href=\"../certificates\">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
 	
 For systems using dynamic path validation, you can *optionally* distribute the CA certificates [issued by the Federal Common Policy CA (FCPCA) G2](#certificates-issued-by-the-federal-common-policy-ca-g2) to simplify path building. Sample procedures for the distribution of intermediate CA certificates are below:
 

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -5,7 +5,10 @@ collection: common
 permalink: common/certificates/
 ---
 
-To simplify certificate path building within your enterprise, you can *optionally* distribute the CA certificates [issued by the Federal Common Policy CA (FCPCA) G2](#certificates-issued-by-the-federal-common-policy-ca-g2). Sample procedures for the distribution of intermediate CA certificates are below:
+
+{% include alert-warning.html content="Important! If your enterprise systems do not have <a href="https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target="_blank">dynamic path validation enabled, you'll need to manually distribute the relevant <a href="../certificates">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
+	
+For systems using dynamic path validation, you can *optionally* distribute the CA certificates [issued by the Federal Common Policy CA (FCPCA) G2](#certificates-issued-by-the-federal-common-policy-ca-g2) to simplify path building. Sample procedures for the distribution of intermediate CA certificates are below:
 
 
 ### Use Microsoft Group Policy Object (GPO)

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -149,7 +149,7 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
 
-{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq/#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
 
 
 #### Issued to: Verizon SSP CA A2

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -149,7 +149,7 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
 
-{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in the <a href=\"../faq\">FAQ</a>." %}
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in the <a href=\"../faq/#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\" target=\"_blank\">FAQ</a>." %}
 
 
 #### Issued to: Verizon SSP CA A2

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -149,7 +149,7 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
 
-{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq\">FAQ</a>." %}
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq/#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
 
 
 #### Issued to: Verizon SSP CA A2

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -6,7 +6,7 @@ permalink: common/certificates/
 ---
 
 
-{% include alert-warning.html content="Important! If your enterprise systems <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation enabled, you'll need to manually distribute the relevant <a href=\"../certificates\">intermediate CA certificates issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
+{% include alert-warning.html content="Important! If your enterprise systems <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled, you'll need to manually distribute the relevant <a href=\"../certificates\">intermediate CA certificates</a> issued by the FCPCA G2. Otherwise, systems will not have enough information to build a path to the new FCPCA G2.  If you have questions about which certificates you need to distribute, email us at fpkirootupdate@gsa.gov." %}
 	
 For systems using dynamic path validation, you can *optionally* distribute the CA certificates [issued by the Federal Common Policy CA (FCPCA) G2](#certificates-issued-by-the-federal-common-policy-ca-g2) to simplify path building. Sample procedures for the distribution of intermediate CA certificates are below:
 
@@ -148,6 +148,9 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-1 Thumbprint | 07f5dc58f83778d5b5738a988292c00a674a0f40 |
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
+
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq\">FAQ</a>." %}
+
 
 #### Issued to: Verizon SSP CA A2
 

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -1,6 +1,6 @@
 ---
 layout: default 
-title: 6. Distribute the CA certificates issued by the Federal Common Policy CA G2 (optional)
+title: 6. Distribute the CA certificates issued by the Federal Common Policy CA G2
 collection: common
 permalink: common/certificates/
 ---

--- a/_common/06_distribute_intermediate_certs.md
+++ b/_common/06_distribute_intermediate_certs.md
@@ -149,7 +149,7 @@ The following certificates are published in the Federal Common Policy CA G2 cert
 | SHA-256 Thumbprint | e3d6b1b33d0a5df0630b32bf17f9fb632b0471a6cac561f164aa6429ef0699a1 |
 | Download Location | Click [here](../../certs/Entrust_Managed_Services_Root_CA.cer) |
 
-{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"../faq#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
+{% include alert-warning.html content="Important! To ensure PIV credential certificates issued by the Entrust Federal SSP before August 13, 2019 validate to the Federal Common Policy CA G2, you'll need to distribute an additional intermediate CA certificate to systems that <b>do not</b> have <a href=\"https://fpki.idmanagement.gov/truststores/#how-do-i-set-dynamic-path-validation-for-the-microsoft-trust-store-in-windows-operating-systems\" target=\"_blank\">dynamic path validation</a> enabled.  Learn more in our <a href=\"https://fpki.idmanagement.gov/common/faq/#why-arent-some-entrust-federal-shared-service-provider-issued-piv-credential-certificates-chaining-to-fcpca-g2\">FAQ</a>." %}
 
 
 #### Issued to: Verizon SSP CA A2

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3345,6 +3345,21 @@
   aia_uri: http://crl-server.orc.com/caCerts/WIDEPOINTNFIROOT2.p7c
   sia_uri:
   ocsp_uri: http://widepointnfiroot2.eva.orc.com
+  
+- notice_date: February 3, 2021
+  change_type: CA Certificate Issuance
+  start_datetime:
+  system: WidePoint Non-Federal Issuer
+  change_description: WidePoint NFI Root 2 issued a modified certificate to WidePoint NFI CA 6.
+  contact: pkipolicy at orc dot com
+  ca_certificate_hash: 8a17d236acb45af809c0a4555f7142d82ae08736
+  ca_certificate_issuer: CN=WidePoint NFI Root 2, OU=Certification Authorities, O=WidePoint, C=US
+  ca_certificate_subject: CN=WidePoint NFI CA 6, O=ORC PKI, C=US
+  cdp_uri: http://crl-server.orc.com/CRLs/WIDEPOINTNFIROOT2.crl
+  aia_uri: http://crl-server.orc.com/caCerts/WIDEPOINTNFIROOT2.p7c
+  sia_uri:
+  ocsp_uri: http://widepointnfiroot2.eva.orc.com  
+
 #- notice_date:  
 #  change_type: CA Certificate Issuance
 #  start_datetime:

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -4,7 +4,7 @@ title: Federal PKI Graph
 collection: tools
 permalink: tools/fpkigraph/
 ---
-**Last Update**: February 03, 2021
+**Last Update**: February 09, 2021
 {% include graph.html %}
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -9,7 +9,7 @@ permalink: tools/fpkigraph/
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  
 
-The Federal Common Policy Certificate Authority (CA) (_"COMMON"_) is shown at the center of the Graph, and the rings of dots represent the outbound CAs. 
+The Federal Common Policy Certificate Authority (CA) G2 (_"COMMON"_) is shown at the center of the Graph, and the rings of dots represent the outbound CAs. 
 
 - Click on any dot in the Graph to see a CA's inbound and outbound _CA_ certificates.
 - _Inbound_ means the CA certificate is signed by the _Inbound_ CA.
@@ -25,7 +25,7 @@ The Graph uses information published in each CA certificate's AIA and SIA extens
 
 All CA and End Entity certificates that have a certificate path (trust chain) to COMMON will have an AIA extension in their public certificates. An AIA extension contains a URI where you can find the certificate(s) used to sign that CA or End Entity certificate.  
 
-Most CA certificates will also have an SIA extension with a URI to the CA certificates that have been issued **_by that CA_**. For example, you can find the SIA for COMMON at http://http.fpki.gov/fcpca/caCertsIssuedByfcpca.p7c. 
+Most CA certificates will also have an SIA extension with a URI to the CA certificates that have been issued **_by that CA_**. For example, you can find the SIA for COMMON at http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c. 
 
 - To use this SIA, retrieve the file (.p7c) using the link above and open it.   
 - You will find a dozen or more certificates that are issued by COMMON (Root) to other intermediate or issuing CAs.  

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -9,7 +9,7 @@ permalink: tools/fpkigraph/
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  
 
-The Federal Common Policy Certificate Authority (CA) G2 (_"COMMON"_) is shown at the center of the Graph, and the rings of dots represent the outbound CAs. 
+The Federal Common Policy Certification Authority (CA) G2 (_"COMMON"_) is shown at the center of the Graph, and the rings of dots represent the outbound CAs. 
 
 - Click on any dot in the Graph to see a CA's inbound and outbound _CA_ certificates.
 - _Inbound_ means the CA certificate is signed by the _Inbound_ CA.

--- a/_tools/fpki-certs.gexf
+++ b/_tools/fpki-certs.gexf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
-  <meta lastmodifieddate="2021-02-03">
+  <meta lastmodifieddate="2021-02-09">
     <creator>Gephi 0.8.1</creator>
     <description></description>
   </meta>
@@ -9,799 +9,805 @@
       <node id="CN=Alexion Pharmaceuticals Issue 2 CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" label="Alexion Pharmaceuticals Issue 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.44528" y="52.100933" z="0.0"></viz:position>
+        <viz:position x="299.9722" y="2.1129146E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" label="Boeing PCA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="281.96622" y="102.61236" z="0.0"></viz:position>
+        <viz:position x="299.36182" y="19.422213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton PIVi CA 01,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="Booz Allen Hamilton PIVi CA 01">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-52.094578" y="295.49612" z="0.0"></viz:position>
+        <viz:position x="297.47986" y="38.755417" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Bureau of the Census Agency CA,OU=Department of Commerce,O=U.S. Government,C=US" label="Bureau of the Census Agency CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="34.73713" y="-196.9847" z="0.0"></viz:position>
+        <viz:position x="-32.359226" y="-197.3662" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="229.81761" y="192.83926" z="0.0"></viz:position>
+        <viz:position x="294.32626" y="57.93761" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA2,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.86469" y="-229.81761" z="0.0"></viz:position>
+        <viz:position x="289.95193" y="76.86231" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 2,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-52.100933" y="-295.44528" z="0.0"></viz:position>
+        <viz:position x="284.4077" y="95.46593" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 3,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-259.84024" y="-149.9861" z="0.0"></viz:position>
+        <viz:position x="277.59192" y="113.68806" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="200.01112" y="2.6181558E-24" z="0.0"></viz:position>
+        <viz:position x="269.65707" y="131.3952" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="6.980727" y="199.88397" z="0.0"></viz:position>
+        <viz:position x="260.60324" y="148.58733" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Class 3 SSP Intermediate CA - G4,O=DigiCert,Inc.,C=US" label="DigiCert Class 3 SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-187.93086" y="-68.40612" z="0.0"></viz:position>
+        <viz:position x="250.44308" y="165.14366" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.00556" y="-2.298948E-25" z="0.0"></viz:position>
+        <viz:position x="100.00556" y="-1.0416694E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federated ID L3 CA,OU=www.digicert.com,O=DigiCert Inc,C=US" label="DigiCert Federated ID L3 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-199.50249" y="13.951917" z="0.0"></viz:position>
+        <viz:position x="239.25293" y="181.03874" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DocuSign Root CA,OU=TSCP,O=DocuSign Inc.,C=US" label="DocuSign Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-150.01152" y="259.7894" z="0.0"></viz:position>
+        <viz:position x="227.04549" y="196.12001" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.08403" y="319.24973" z="0.0"></viz:position>
+        <viz:position x="213.84622" y="210.41289" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-241.05862" y="319.1989" z="0.0"></viz:position>
+        <viz:position x="199.7568" y="223.79019" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-372.96246" y="-144.49275" z="0.0"></viz:position>
+        <viz:position x="184.85358" y="236.27737" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="372.96246" y="-144.49275" z="0.0"></viz:position>
+        <viz:position x="169.18738" y="247.74727" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-178.31749" y="358.05923" z="0.0"></viz:position>
+        <viz:position x="152.78363" y="258.16174" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.59787" y="269.4536" z="0.0"></viz:position>
+        <viz:position x="135.7441" y="267.52078" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="178.29208" y="-358.05923" z="0.0"></viz:position>
+        <viz:position x="118.16412" y="275.76077" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.466324" y="384.71213" z="0.0"></viz:position>
+        <viz:position x="100.056435" y="282.78006" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="340.1041" y="210.5909" z="0.0"></viz:position>
+        <viz:position x="81.541824" y="288.68033" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="36.905228" y="-398.34372" z="0.0"></viz:position>
+        <viz:position x="62.68707" y="293.35983" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-241.05862" y="-319.1989" z="0.0"></viz:position>
+        <viz:position x="43.56845" y="296.8186" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="399.9714" y="7.4613625E-25" z="0.0"></viz:position>
+        <viz:position x="24.267036" y="299.00577" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.59787" y="-269.4536" z="0.0"></viz:position>
+        <viz:position x="4.858732" y="299.97217" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-399.9714" y="4.043077E-13" z="0.0"></viz:position>
+        <viz:position x="-14.570236" y="299.61615" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-340.05325" y="-210.56548" z="0.0"></viz:position>
+        <viz:position x="-33.93602" y="298.03937" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-393.20642" y="-73.49255" z="0.0"></viz:position>
+        <viz:position x="-53.15637" y="295.24182" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="340.05325" y="-210.56548" z="0.0"></viz:position>
+        <viz:position x="-72.157364" y="291.17267" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="372.96246" y="144.49275" z="0.0"></viz:position>
+        <viz:position x="-90.8627" y="285.88278" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-37,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-37">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="393.20642" y="73.505264" z="0.0"></viz:position>
+        <viz:position x="-109.17386" y="279.42303" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-38,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-38">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="393.15558" y="-73.49255" z="0.0"></viz:position>
+        <viz:position x="-127.02722" y="271.74252" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-45,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-45">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.59787" y="269.50446" z="0.0"></viz:position>
+        <viz:position x="-144.34016" y="263.04468" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-46,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-46">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="178.29208" y="358.05923" z="0.0"></viz:position>
+        <viz:position x="-161.09993" y="253.08803" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-100.00556" y="-173.23106" z="0.0"></viz:position>
+        <viz:position x="-177.14761" y="242.12677" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Root CA 3,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Root CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.86469" y="229.81761" z="0.0"></viz:position>
+        <viz:position x="-192.40692" y="230.14822" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-53,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-53">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-36.905228" y="-398.29288" z="0.0"></viz:position>
+        <viz:position x="-206.90324" y="217.2287" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-54,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-54">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.479034" y="-384.71213" z="0.0"></viz:position>
+        <viz:position x="-220.53488" y="203.36818" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-60,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-60">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-340.05325" y="210.56548" z="0.0"></viz:position>
+        <viz:position x="-233.25095" y="188.6684" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOE SSP CA,OU=Certification Authorities,OU=Department of Energy,O=U.S. Government,C=US" label="DOE SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.25433" y="-55.133717" z="0.0"></viz:position>
+        <viz:position x="181.49654" y="-83.98331" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 4,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="295.44528" y="-52.100933" z="0.0"></viz:position>
+        <viz:position x="-244.97517" y="173.18022" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA 2 CA,OU=Eid Passport PIV-I LRA Network,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="300.02304" y="-2.3371343E-24" z="0.0"></viz:position>
+        <viz:position x="-255.68208" y="156.97992" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA CA 3,OU=RAPIDGate PIV Interoperable LRA,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.96622" y="-102.61236" z="0.0"></viz:position>
+        <viz:position x="-265.3336" y="140.09297" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Entrust Derived Credential SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Derived Credential SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-176.58812" y="93.90184" z="0.0"></viz:position>
+        <viz:position x="-145.20483" y="137.52435" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Digital Certificate Service Signing CA 1,O=Exostar UK Limited,C=GB" label="Exostar Digital Certificate Service Signing CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-8.544245E-13" y="-300.02304" z="0.0"></viz:position>
+        <viz:position x="-273.8279" y="122.614746" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Root CA 2,OU=Certification Authorities,O=Exostar LLC,C=US" label="Exostar Federated Identity Service Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="61.8033" y="190.19432" z="0.0"></viz:position>
+        <viz:position x="-281.20325" y="104.63422" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Signing CA 3,DC=evincible,DC=com" label="Exostar Federated Identity Service Signing CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="281.91537" y="-102.61236" z="0.0"></viz:position>
+        <viz:position x="-287.30698" y="86.208626" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA G4,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="76.595276" y="64.2734" z="0.0"></viz:position>
+        <viz:position x="-292.2917" y="67.42699" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA G2,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="1.810815E-24" y="1.784126E-24" z="0.0"></viz:position>
+        <viz:position x="-296.10648" y="48.368767" z="0.0"></viz:position>
+        <viz:color r="153" g="0" b="153"></viz:color>
+      </node>
+      <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
+        <attvalues></attvalues>
+        <viz:size value="10.0"></viz:size>
+        <viz:position x="-1.8014046E-25" y="-2.0391384E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions Intermediate CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="499.9706" y="-1.7382747E-24" z="0.0"></viz:position>
+        <viz:position x="-298.548" y="29.102325" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions PKI Root CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions PKI Root CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="353.5323" y="353.5323" z="0.0"></viz:position>
+        <viz:position x="-299.8196" y="9.714286" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=FTI Certification Authority,OU=FTI PKI Trust Infrastructure,O=Foundation for Trusted Identity,C=US" label="FTI Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-229.81761" y="192.83926" z="0.0"></viz:position>
+        <viz:position x="-299.8196" y="-9.715875" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=HHS-FPKI-Intermediate-CA-E1,OU=Certification Authorities,OU=HHS,O=U.S. Government,C=US" label="HHS-FPKI-Intermediate-CA-E1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.59428" y="-105.982124" z="0.0"></viz:position>
+        <viz:position x="129.46236" y="-152.453" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA Component S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA Component S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="109.479034" y="-384.71213" z="0.0"></viz:position>
+        <viz:position x="-298.548" y="-29.102325" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.59787" y="-269.4536" z="0.0"></viz:position>
+        <viz:position x="-296.10648" y="-48.375122" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-36.905228" y="398.29288" z="0.0"></viz:position>
+        <viz:position x="-292.2917" y="-67.4397" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22C,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22C">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-178.29208" y="-358.05923" z="0.0"></viz:position>
+        <viz:position x="-287.30698" y="-86.208626" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust Global Common Root CA 1,O=IdenTrust,C=US" label="IdenTrust Global Common Root CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-143.85695" y="138.92311" z="0.0"></viz:position>
+        <viz:position x="-281.1524" y="-104.64693" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust SAFE-BioPharma CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IdenTrust SAFE-BioPharma CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.44528" y="-52.094578" z="0.0"></viz:position>
+        <viz:position x="-273.7771" y="-122.614746" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-102.59965" y="281.91537" z="0.0"></viz:position>
+        <viz:position x="-265.28275" y="-140.06757" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC Server CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC Server CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="229.81761" y="-192.83926" z="0.0"></viz:position>
+        <viz:position x="-255.68208" y="-156.95451" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Leidos FBCA Cloud PKI CA-1,O=Leidos" label="Leidos FBCA Cloud PKI CA-1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.44528" y="52.100933" z="0.0"></viz:position>
+        <viz:position x="-244.97517" y="-173.18022" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Certification Authority 4 G2,OU=Certification Authorities,O=Lockheed Martin Corporation,C=US" label="Lockheed Martin Certification Authority 4 G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="36.911583" y="398.29288" z="0.0"></viz:position>
+        <viz:position x="-233.25095" y="-188.6684" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Root Certification Authority 2,OU=Certification Authorities,O=Lockheed Martin Corporation,L=Denver,ST=Colorado,C=US" label="Lockheed Martin Root Certification Authority 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="149.9861" y="-259.7894" z="0.0"></viz:position>
+        <viz:position x="-220.56029" y="-203.36818" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3,OID.2.5.4.97=NTRNL-27370985,O=Ministerie van Defensie,C=NL" label="Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="52.094578" y="-295.44528" z="0.0"></viz:position>
+        <viz:position x="-206.90324" y="-217.2287" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Agency CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="182.69185" y="-81.33837" z="0.0"></viz:position>
+        <viz:position x="159.2434" y="-121.03796" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Device CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-123.14881" y="157.59032" z="0.0"></viz:position>
+        <viz:position x="-74.03934" y="185.79457" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NextgenIDRootCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NextgenIDRootCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="102.61236" y="-281.91537" z="0.0"></viz:position>
+        <viz:position x="-192.43234" y="-230.17365" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NGIDTrustCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NGIDTrustCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="109.466324" y="384.71213" z="0.0"></viz:position>
+        <viz:position x="-177.14761" y="-242.12677" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Root CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Root CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="102.59965" y="281.96622" z="0.0"></viz:position>
+        <viz:position x="-161.07451" y="-253.11345" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Signing CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Signing CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-393.15558" y="73.49255" z="0.0"></viz:position>
+        <viz:position x="-144.36559" y="-262.99387" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="133.81125" y="148.63818" z="0.0"></viz:position>
+        <viz:position x="159.21797" y="121.03796" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-195.61137" y="41.578384" z="0.0"></viz:position>
+        <viz:position x="129.46236" y="152.42758" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.07828" y="-27.837074" z="0.0"></viz:position>
+        <viz:position x="195.30618" y="-42.98987" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="34.724426" y="196.95927" z="0.0"></viz:position>
+        <viz:position x="-189.5331" y="63.856945" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA 6,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-372.96246" y="144.49275" z="0.0"></viz:position>
+        <viz:position x="-127.02722" y="-271.74252" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC NFI CA 3,O=ORC PKI,C=US" label="ORC NFI CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-300.02304" y="4.3642826E-13" z="0.0"></viz:position>
+        <viz:position x="-109.17386" y="-279.47385" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="17.368565" y="98.47964" z="0.0"></viz:position>
+        <viz:position x="62.356445" y="78.184784" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Class 3 MASCA,OU=Class3-g2,O=cas,DC=raytheon,DC=com" label="Raytheon Class 3 MASCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-229.84303" y="-192.86469" z="0.0"></viz:position>
+        <viz:position x="-90.8627" y="-285.88278" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SAFE Bridge CA 02,OU=Certification Authorities,O=SAFE-Biopharma,C=US" label="SAFE Bridge CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-74.92946" y="185.4385" z="0.0"></viz:position>
+        <viz:position x="-72.157364" y="-291.17267" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SAFE Identity Bridge CA,OU=Certification Authorities,O=SAFE Identity,C=US" label="SAFE Identity Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-187.93086" y="68.40612" z="0.0"></viz:position>
+        <viz:position x="-53.15637" y="-295.24182" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.83926" y="229.81761" z="0.0"></viz:position>
+        <viz:position x="-33.93602" y="-298.03937" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I Device CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="1.8371333E-14" y="300.02304" z="0.0"></viz:position>
+        <viz:position x="-14.568647" y="-299.61615" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=STRAC Bridge Root Certification Authority,OU=STRAC PKI Trust Infrastructure,O=STRAC,C=US" label="STRAC Bridge Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="133.81125" y="-148.61276" z="0.0"></viz:position>
+        <viz:position x="4.857938" y="-299.92133" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. CA1,OU=SureID PIV-I,O=SureID,Inc.,C=US" label="SureID Inc. CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="259.7894" y="-150.01152" z="0.0"></viz:position>
+        <viz:position x="24.263859" y="-299.00577" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. Device CA2,O=SureID,Inc.,C=US" label="SureID Inc. Device CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.83926" y="-229.81761" z="0.0"></viz:position>
+        <viz:position x="43.574806" y="-296.86945" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec Class 3 SSP Intermediate CA - G3,OU=Symantec Trust Network,O=Symantec Corporation,C=US" label="Symantec Class 3 SSP Intermediate CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="111.83151" y="165.8049" z="0.0"></viz:position>
+        <viz:position x="62.68707" y="-293.35983" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-50.00278" y="86.60283" z="0.0"></viz:position>
+        <viz:position x="-22.254719" y="97.487785" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Mobile eIDAS QCA G2,OU=Individual Subscriber CA,O=Trans Sped SRL,C=RO" label="Trans Sped Mobile eIDAS QCA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="52.094578" y="295.44528" z="0.0"></viz:position>
+        <viz:position x="81.541824" y="-288.73117" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Root CA G2,OU=Trans Sped CA,O=Trans Sped SRL,C=RO" label="Trans Sped Root CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="3.062124E-14" y="499.9706" z="0.0"></viz:position>
+        <viz:position x="100.056435" y="-282.78006" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-176.61354" y="-93.88914" z="0.0"></viz:position>
+        <viz:position x="118.17683" y="-275.76077" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.59428" y="105.982124" z="0.0"></viz:position>
+        <viz:position x="181.49654" y="83.98331" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="153.19055" y="128.5468" z="0.0"></viz:position>
+        <viz:position x="-112.238434" y="-165.52515" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-143.85695" y="-138.94853" z="0.0"></viz:position>
+        <viz:position x="-198.84125" y="-21.622095" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-195.61137" y="-41.578384" z="0.0"></viz:position>
+        <viz:position x="-74.02663" y="-185.79457" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-123.13611" y="-157.61572" z="0.0"></viz:position>
+        <viz:position x="-189.5585" y="-63.8633" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.96543" y="34.209415" z="0.0"></viz:position>
+        <viz:position x="-90.09975" y="43.390423" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="153.21597" y="-128.5468" z="0.0"></viz:position>
+        <viz:position x="93.672966" y="-176.68985" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.25433" y="55.12736" z="0.0"></viz:position>
+        <viz:position x="-32.352875" y="197.3662" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-20.903637" y="198.89212" z="0.0"></viz:position>
+        <viz:position x="53.512417" y="192.71211" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="87.670975" y="-179.74171" z="0.0"></viz:position>
+        <viz:position x="195.30618" y="42.98987" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=US DoD CCEB Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="US DoD CCEB Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-353.5323" y="353.5323" z="0.0"></viz:position>
+        <viz:position x="135.76952" y="-267.52078" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=USPTO_INTR_CA1,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=uspto,DC=gov" label="USPTO_INTR_CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-20.906815" y="-198.89212" z="0.0"></viz:position>
+        <viz:position x="152.78363" y="-258.16174" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Patient Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Patient Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="149.9861" y="259.84024" z="0.0"></viz:position>
+        <viz:position x="169.18738" y="-247.74727" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Provider Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Provider Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-259.7894" y="150.01152" z="0.0"></viz:position>
+        <viz:position x="184.85358" y="-236.27737" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.96543" y="-34.20306" z="0.0"></viz:position>
+        <viz:position x="-90.09975" y="-43.384068" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs CA B3,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs CA B3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="111.84422" y="-165.8303" z="0.0"></viz:position>
+        <viz:position x="53.512417" y="-192.73752" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs User CA B1,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs User CA B1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-74.92946" y="-185.4385" z="0.0"></viz:position>
+        <viz:position x="-171.37454" y="-103.10829" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI CA 5,O=ORC PKI,C=US" label="WidePoint NFI CA 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="259.84024" y="149.9861" z="0.0"></viz:position>
+        <viz:position x="199.78223" y="-223.79019" z="0.0"></viz:position>
+        <viz:color r="153" g="0" b="153"></viz:color>
+      </node>
+      <node id="CN=WidePoint NFI CA 6,O=ORC PKI,C=US" label="WidePoint NFI CA 6">
+        <attvalues></attvalues>
+        <viz:size value="10.0"></viz:size>
+        <viz:position x="213.87164" y="-210.41289" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint NFI Root 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="6.980727" y="-199.88397" z="0.0"></viz:position>
+        <viz:position x="227.04549" y="-196.14543" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC ECA 7,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="WidePoint ORC ECA 7">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.05862" y="-319.1989" z="0.0"></viz:position>
+        <viz:position x="239.22751" y="-181.01332" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint ORC NFI 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-150.01152" y="-259.84024" z="0.0"></viz:position>
+        <viz:position x="250.44308" y="-165.14366" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC SSP 5,O=ORC PKI,C=US" label="WidePoint ORC SSP 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-49.996426" y="-86.60283" z="0.0"></viz:position>
+        <viz:position x="260.65405" y="-148.58733" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Department of Veterans Affairs CA,OU=Certification Authorities,OU=Department of Veterans Affairs,O=U.S. Government,C=US" label="Department of Veterans Affairs CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.05286" y="27.837074" z="0.0"></viz:position>
+        <viz:position x="200.01112" y="-1.0881825E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=DHS CA4,OU=Certification Authorities,OU=Department of Homeland Security,O=U.S. Government,C=US" label="DHS CA4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="61.809654" y="-190.19432" z="0.0"></viz:position>
+        <viz:position x="10.826942" y="-199.73137" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services NFI Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services NFI Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-100.00556" y="173.20566" z="0.0"></viz:position>
+        <viz:position x="269.65707" y="-131.42062" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="17.368565" y="-98.47964" z="0.0"></viz:position>
+        <viz:position x="-22.251541" y="-97.487785" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-48.381485" y="-194.08543" z="0.0"></viz:position>
+        <viz:position x="-145.20483" y="-137.52435" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust NFI Medium Assurance SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust NFI Medium Assurance SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-102.59965" y="-281.91537" z="0.0"></viz:position>
+        <viz:position x="277.64273" y="-113.68806" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Fiscal Service,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Fiscal Service">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-199.50249" y="-13.951917" z="0.0"></viz:position>
+        <viz:position x="-171.37454" y="103.10829" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO PCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="182.69185" y="81.33837" z="0.0"></viz:position>
+        <viz:position x="284.45856" y="-95.46593" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.96622" y="102.61236" z="0.0"></viz:position>
+        <viz:position x="289.95193" y="-76.86231" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=NASA Operational CA,OU=Certification Authorities,OU=NASA,O=U.S. Government,C=US" label="NASA Operational CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-48.381485" y="194.08543" z="0.0"></viz:position>
+        <viz:position x="10.826942" y="199.70595" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=OCIO CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury OCIO CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.78662" y="117.56646" z="0.0"></viz:position>
+        <viz:position x="-112.25114" y="165.55055" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Social Security Administration Certification Authority,OU=SSA,O=U.S. Government,C=US" label="Social Security Administration Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.78662" y="-117.55375" z="0.0"></viz:position>
+        <viz:position x="-198.81583" y="21.622095" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=U.S. Department of State PIV CA2,OU=Certification Authorities,OU=PIV,OU=Department of State,O=U.S. Government,C=US" label="U.S. Department of State PIV CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="87.670975" y="179.76714" z="0.0"></viz:position>
+        <viz:position x="93.672966" y="176.68985" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="76.60799" y="-64.28611" z="0.0"></viz:position>
+        <viz:position x="62.356445" y="-78.184784" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services NFI Root CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-499.9706" y="6.124248E-14" z="0.0"></viz:position>
+        <viz:position x="294.32626" y="-57.931255" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-353.5323" y="-353.5323" z="0.0"></viz:position>
-        <viz:color r="153" g="0" b="153"></viz:color>
-      </node>
-      <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US">
-        <attvalues></attvalues>
-        <viz:size value="10.0"></viz:size>
-        <viz:position x="-9.1860906E-14" y="-499.9706" z="0.0"></viz:position>
+        <viz:position x="297.47986" y="-38.755417" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Australian Defence Interoperability CA,OU=CAs,OU=PKI,OU=DoD,O=GOV,C=AU">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="353.5323" y="-353.5323" z="0.0"></viz:position>
+        <viz:position x="299.36182" y="-19.419035" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
     </nodes>
@@ -1134,6 +1140,38 @@
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>
+      <edge id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=ORC SSP 4,O=ORC PKI,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA" weight="2.0">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA" weight="2.0">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
       <edge id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" source="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" target="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
@@ -1350,6 +1388,10 @@
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>
+      <edge id="CN=WidePoint NFI CA 6,O=ORC PKI,C=US" source="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" target="CN=WidePoint NFI CA 6,O=ORC PKI,C=US" label="WidePoint NFI CA 6">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
       <edge id="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" source="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" target="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint ORC NFI 4">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
@@ -1423,34 +1465,6 @@
         <attvalues></attvalues>
       </edge>
       <edge id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" source="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com" target="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=ORC SSP 4,O=ORC PKI,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA" weight="2.0">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA" weight="2.0">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>

--- a/_tools/fpki-certs.gexf
+++ b/_tools/fpki-certs.gexf
@@ -9,805 +9,805 @@
       <node id="CN=Alexion Pharmaceuticals Issue 2 CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" label="Alexion Pharmaceuticals Issue 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.9722" y="2.1129146E-24" z="0.0"></viz:position>
+        <viz:position x="-135.05743" y="-267.87683" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" label="Boeing PCA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.36182" y="19.422213" z="0.0"></viz:position>
+        <viz:position x="-87.86171" y="-286.8492" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton PIVi CA 01,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="Booz Allen Hamilton PIVi CA 01">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="297.47986" y="38.755417" z="0.0"></viz:position>
+        <viz:position x="63.208424" y="-293.30896" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Bureau of the Census Agency CA,OU=Department of Commerce,O=U.S. Government,C=US" label="Bureau of the Census Agency CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-32.359226" y="-197.3662" z="0.0"></viz:position>
+        <viz:position x="-143.85695" y="138.92311" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="294.32626" y="57.93761" z="0.0"></viz:position>
+        <viz:position x="-38.10054" y="297.5307" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA2,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="289.95193" y="76.86231" z="0.0"></viz:position>
+        <viz:position x="-216.5929" y="207.56448" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 2,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="284.4077" y="95.46593" z="0.0"></viz:position>
+        <viz:position x="-87.849" y="286.8492" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 3,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="277.59192" y="113.68806" z="0.0"></viz:position>
+        <viz:position x="-178.41922" y="-241.2112" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="269.65707" y="131.3952" z="0.0"></viz:position>
+        <viz:position x="-187.93086" y="-68.40612" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="260.60324" y="148.58733" z="0.0"></viz:position>
+        <viz:position x="-199.50249" y="13.951917" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Class 3 SSP Intermediate CA - G4,O=DigiCert,Inc.,C=US" label="DigiCert Class 3 SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="250.44308" y="165.14366" z="0.0"></viz:position>
+        <viz:position x="-99.99285" y="-173.20566" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.00556" y="-1.0416694E-24" z="0.0"></viz:position>
+        <viz:position x="99.99285" y="-2.0384572E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federated ID L3 CA,OU=www.digicert.com,O=DigiCert Inc,C=US" label="DigiCert Federated ID L3 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="239.25293" y="181.03874" z="0.0"></viz:position>
+        <viz:position x="34.724426" y="196.9847" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DocuSign Root CA,OU=TSCP,O=DocuSign Inc.,C=US" label="DocuSign Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="227.04549" y="196.12001" z="0.0"></viz:position>
+        <viz:position x="-248.53568" y="-167.99207" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="213.84622" y="210.41289" z="0.0"></viz:position>
+        <viz:position x="-241.05862" y="319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="199.7568" y="223.79019" z="0.0"></viz:position>
+        <viz:position x="-295.6487" y="269.50446" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="184.85358" y="236.27737" z="0.0"></viz:position>
+        <viz:position x="178.31749" y="-358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.18738" y="247.74727" z="0.0"></viz:position>
+        <viz:position x="-178.31749" y="358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="152.78363" y="258.16174" z="0.0"></viz:position>
+        <viz:position x="295.59787" y="269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="135.7441" y="267.52078" z="0.0"></viz:position>
+        <viz:position x="36.905228" y="-398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="118.16412" y="275.76077" z="0.0"></viz:position>
+        <viz:position x="-241.05862" y="-319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.056435" y="282.78006" z="0.0"></viz:position>
+        <viz:position x="399.9714" y="-3.993536E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="81.541824" y="288.68033" z="0.0"></viz:position>
+        <viz:position x="295.59787" y="-269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="62.68707" y="293.35983" z="0.0"></viz:position>
+        <viz:position x="-399.9714" y="4.043077E-13" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="43.56845" y="296.8186" z="0.0"></viz:position>
+        <viz:position x="-340.05325" y="-210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-43">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="24.267036" y="299.00577" z="0.0"></viz:position>
+        <viz:position x="-393.15558" y="-73.505264" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="4.858732" y="299.97217" z="0.0"></viz:position>
+        <viz:position x="340.05325" y="-210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-14.570236" y="299.61615" z="0.0"></viz:position>
+        <viz:position x="340.05325" y="210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-50">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-33.93602" y="298.03937" z="0.0"></viz:position>
+        <viz:position x="372.96246" y="144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-53.15637" y="295.24182" z="0.0"></viz:position>
+        <viz:position x="393.15558" y="-73.49255" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-52">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-72.157364" y="291.17267" z="0.0"></viz:position>
+        <viz:position x="241.08403" y="319.24973" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-90.8627" y="285.88278" z="0.0"></viz:position>
+        <viz:position x="178.31749" y="358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-37,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-37">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.17386" y="279.42303" z="0.0"></viz:position>
+        <viz:position x="-36.911583" y="-398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-38,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-38">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-127.02722" y="271.74252" z="0.0"></viz:position>
+        <viz:position x="-109.466324" y="-384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-45,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-45">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-144.34016" y="263.04468" z="0.0"></viz:position>
+        <viz:position x="-340.05325" y="210.56548" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-46,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-46">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.09993" y="253.08803" z="0.0"></viz:position>
+        <viz:position x="109.466324" y="384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-177.14761" y="242.12677" z="0.0"></viz:position>
+        <viz:position x="-161.78662" y="117.55375" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Root CA 3,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Root CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.40692" y="230.14822" z="0.0"></viz:position>
+        <viz:position x="-38.10689" y="-297.5307" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-53,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-53">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-206.90324" y="217.2287" z="0.0"></viz:position>
+        <viz:position x="36.911583" y="398.34372" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-54,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-54">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-220.53488" y="203.36818" z="0.0"></viz:position>
+        <viz:position x="109.466324" y="-384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-60,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-60">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-233.25095" y="188.6684" z="0.0"></viz:position>
+        <viz:position x="-295.59787" y="-269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOE SSP CA,OU=Certification Authorities,OU=Department of Energy,O=U.S. Government,C=US" label="DOE SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="181.49654" y="-83.98331" z="0.0"></viz:position>
+        <viz:position x="169.59428" y="-105.99483" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 4,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-244.97517" y="173.18022" z="0.0"></viz:position>
+        <viz:position x="157.31055" y="-255.47864" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA 2 CA,OU=Eid Passport PIV-I LRA Network,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-255.68208" y="156.97992" z="0.0"></viz:position>
+        <viz:position x="198.23087" y="-225.18896" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA CA 3,OU=RAPIDGate PIV Interoperable LRA,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-265.3336" y="140.09297" z="0.0"></viz:position>
+        <viz:position x="-135.08284" y="267.87683" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Entrust Derived Credential SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Derived Credential SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-145.20483" y="137.52435" z="0.0"></viz:position>
+        <viz:position x="-48.381485" y="-194.06001" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Digital Certificate Service Signing CA 1,O=Exostar UK Limited,C=GB" label="Exostar Digital Certificate Service Signing CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-273.8279" y="122.614746" z="0.0"></viz:position>
+        <viz:position x="295.64874" y="50.69581" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Root CA 2,OU=Certification Authorities,O=Exostar LLC,C=US" label="Exostar Federated Identity Service Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.20325" y="104.63422" z="0.0"></viz:position>
+        <viz:position x="-99.99285" y="173.23106" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Signing CA 3,DC=evincible,DC=com" label="Exostar Federated Identity Service Signing CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-287.30698" y="86.208626" z="0.0"></viz:position>
+        <viz:position x="261.87485" y="146.29843" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA G4,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-292.2917" y="67.42699" z="0.0"></viz:position>
+        <viz:position x="76.595276" y="64.28611" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA G2,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-296.10648" y="48.368767" z="0.0"></viz:position>
-        <viz:color r="153" g="0" b="153"></viz:color>
-      </node>
-      <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
-        <attvalues></attvalues>
-        <viz:size value="10.0"></viz:size>
-        <viz:position x="-1.8014046E-25" y="-2.0391384E-24" z="0.0"></viz:position>
+        <viz:position x="-3.399586E-24" y="2.4387586E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions Intermediate CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-298.548" y="29.102325" z="0.0"></viz:position>
+        <viz:position x="499.9706" y="-1.8060148E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions PKI Root CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions PKI Root CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-299.8196" y="9.714286" z="0.0"></viz:position>
+        <viz:position x="353.5323" y="353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=FTI Certification Authority,OU=FTI PKI Trust Infrastructure,O=Foundation for Trusted Identity,C=US" label="FTI Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-299.8196" y="-9.715875" z="0.0"></viz:position>
+        <viz:position x="299.9722" y="3.1234316E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=HHS-FPKI-Intermediate-CA-E1,OU=Certification Authorities,OU=HHS,O=U.S. Government,C=US" label="HHS-FPKI-Intermediate-CA-E1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="129.46236" y="-152.453" z="0.0"></viz:position>
+        <viz:position x="192.25433" y="55.133717" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA Component S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA Component S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-298.548" y="-29.102325" z="0.0"></viz:position>
+        <viz:position x="-36.905228" y="398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-296.10648" y="-48.375122" z="0.0"></viz:position>
+        <viz:position x="-178.29208" y="-358.05923" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-292.2917" y="-67.4397" z="0.0"></viz:position>
+        <viz:position x="-372.96246" y="144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22C,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22C">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-287.30698" y="-86.208626" z="0.0"></viz:position>
+        <viz:position x="241.08403" y="-319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust Global Common Root CA 1,O=IdenTrust,C=US" label="IdenTrust Global Common Root CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.1524" y="-104.64693" z="0.0"></viz:position>
+        <viz:position x="-195.61137" y="41.58474" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust SAFE-BioPharma CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IdenTrust SAFE-BioPharma CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-273.7771" y="-122.614746" z="0.0"></viz:position>
+        <viz:position x="12.732764" y="-299.71786" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-265.28275" y="-140.06757" z="0.0"></viz:position>
+        <viz:position x="111.86966" y="-278.35486" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC Server CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC Server CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-255.68208" y="-156.95451" z="0.0"></viz:position>
+        <viz:position x="157.28513" y="255.45322" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Leidos FBCA Cloud PKI CA-1,O=Leidos" label="Leidos FBCA Cloud PKI CA-1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-244.97517" y="-173.18022" z="0.0"></viz:position>
+        <viz:position x="-216.5929" y="-207.56448" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Certification Authority 4 G2,OU=Certification Authorities,O=Lockheed Martin Corporation,C=US" label="Lockheed Martin Certification Authority 4 G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-233.25095" y="-188.6684" z="0.0"></viz:position>
+        <viz:position x="393.15558" y="73.49255" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Lockheed Martin Root Certification Authority 2,OU=Certification Authorities,O=Lockheed Martin Corporation,L=Denver,ST=Colorado,C=US" label="Lockheed Martin Root Certification Authority 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-220.56029" y="-203.36818" z="0.0"></viz:position>
+        <viz:position x="233.40355" y="-188.46494" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3,OID.2.5.4.97=NTRNL-27370985,O=Ministerie van Defensie,C=NL" label="Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-206.90324" y="-217.2287" z="0.0"></viz:position>
+        <viz:position x="-273.37018" y="123.58116" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Agency CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="159.2434" y="-121.03796" z="0.0"></viz:position>
+        <viz:position x="111.83151" y="165.8303" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Device CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-74.03934" y="185.79457" z="0.0"></viz:position>
+        <viz:position x="198.05286" y="-27.833897" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NextgenIDRootCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NextgenIDRootCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-192.43234" y="-230.17365" z="0.0"></viz:position>
+        <viz:position x="198.20544" y="225.18896" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NGIDTrustCA1,OU=Certification Authorities,O=NextgenID,C=US" label="NGIDTrustCA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-177.14761" y="-242.12677" z="0.0"></viz:position>
+        <viz:position x="-372.96246" y="-144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Root CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Root CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.07451" y="-253.11345" z="0.0"></viz:position>
+        <viz:position x="-248.53568" y="167.99207" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Signing CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Signing CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-144.36559" y="-262.99387" z="0.0"></viz:position>
+        <viz:position x="372.96246" y="-144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="159.21797" y="121.03796" z="0.0"></viz:position>
+        <viz:position x="153.19055" y="128.5468" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="129.46236" y="152.42758" z="0.0"></viz:position>
+        <viz:position x="133.83667" y="148.61276" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="195.30618" y="-42.98987" z="0.0"></viz:position>
+        <viz:position x="-143.85695" y="-138.94853" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-189.5331" y="63.856945" z="0.0"></viz:position>
+        <viz:position x="-195.61137" y="-41.578384" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA 6,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-127.02722" y="-271.74252" z="0.0"></viz:position>
+        <viz:position x="-109.479034" y="384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC NFI CA 3,O=ORC PKI,C=US" label="ORC NFI CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.17386" y="-279.47385" z="0.0"></viz:position>
+        <viz:position x="-290.35883" y="-75.60342" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="62.356445" y="78.184784" z="0.0"></viz:position>
+        <viz:position x="17.368565" y="98.49235" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Class 3 MASCA,OU=Class3-g2,O=cas,DC=raytheon,DC=com" label="Raytheon Class 3 MASCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-90.8627" y="-285.88278" z="0.0"></viz:position>
+        <viz:position x="-273.42102" y="-123.56845" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SAFE Bridge CA 02,OU=Certification Authorities,O=SAFE-Biopharma,C=US" label="SAFE Bridge CA 02">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-72.157364" y="-291.17267" z="0.0"></viz:position>
+        <viz:position x="133.81125" y="-148.61276" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SAFE Identity Bridge CA,OU=Certification Authorities,O=SAFE Identity,C=US" label="SAFE Identity Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-53.15637" y="-295.24182" z="0.0"></viz:position>
+        <viz:position x="87.670975" y="179.74171" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-33.93602" y="-298.03937" z="0.0"></viz:position>
+        <viz:position x="-178.39381" y="241.18578" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I Device CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-14.568647" y="-299.61615" z="0.0"></viz:position>
+        <viz:position x="295.64874" y="-50.702164" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=STRAC Bridge Root Certification Authority,OU=STRAC PKI Trust Infrastructure,O=STRAC,C=US" label="STRAC Bridge Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="4.857938" y="-299.92133" z="0.0"></viz:position>
+        <viz:position x="-176.61354" y="-93.88914" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. CA1,OU=SureID PIV-I,O=SureID,Inc.,C=US" label="SureID Inc. CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="24.263859" y="-299.00577" z="0.0"></viz:position>
+        <viz:position x="-290.35883" y="75.590706" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. Device CA2,O=SureID,Inc.,C=US" label="SureID Inc. Device CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="43.574806" y="-296.86945" z="0.0"></viz:position>
+        <viz:position x="282.83093" y="99.9547" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec Class 3 SSP Intermediate CA - G3,OU=Symantec Trust Network,O=Symantec Corporation,C=US" label="Symantec Class 3 SSP Intermediate CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="62.68707" y="-293.35983" z="0.0"></viz:position>
+        <viz:position x="-20.903637" y="-198.91754" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-22.254719" y="97.487785" z="0.0"></viz:position>
+        <viz:position x="-49.996426" y="86.60283" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Mobile eIDAS QCA G2,OU=Individual Subscriber CA,O=Trans Sped SRL,C=RO" label="Trans Sped Mobile eIDAS QCA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="81.541824" y="-288.73117" z="0.0"></viz:position>
+        <viz:position x="282.83093" y="-99.9547" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Root CA G2,OU=Trans Sped CA,O=Trans Sped SRL,C=RO" label="Trans Sped Root CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.056435" y="-282.78006" z="0.0"></viz:position>
+        <viz:position x="3.062124E-14" y="499.9706" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="118.17683" y="-275.76077" z="0.0"></viz:position>
+        <viz:position x="6.979933" y="-199.88397" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="181.49654" y="83.98331" z="0.0"></viz:position>
+        <viz:position x="153.19055" y="-128.5468" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-112.238434" y="-165.52515" z="0.0"></viz:position>
+        <viz:position x="182.69185" y="81.33837" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-198.84125" y="-21.622095" z="0.0"></viz:position>
+        <viz:position x="-48.381485" y="194.06001" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-74.02663" y="-185.79457" z="0.0"></viz:position>
+        <viz:position x="87.683685" y="-179.74171" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-189.5585" y="-63.8633" z="0.0"></viz:position>
+        <viz:position x="111.84422" y="-165.8049" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-90.09975" y="43.390423" z="0.0"></viz:position>
+        <viz:position x="-93.96543" y="34.209415" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="93.672966" y="-176.68985" z="0.0"></viz:position>
+        <viz:position x="-123.13611" y="-157.59032" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-32.352875" y="197.3662" z="0.0"></viz:position>
+        <viz:position x="198.05286" y="27.833897" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="53.512417" y="192.71211" z="0.0"></viz:position>
+        <viz:position x="61.8033" y="190.19432" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="195.30618" y="42.98987" z="0.0"></viz:position>
+        <viz:position x="-20.906815" y="198.91754" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=US DoD CCEB Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="US DoD CCEB Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="135.76952" y="-267.52078" z="0.0"></viz:position>
+        <viz:position x="-353.5323" y="353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=USPTO_INTR_CA1,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=uspto,DC=gov" label="USPTO_INTR_CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="152.78363" y="-258.16174" z="0.0"></viz:position>
+        <viz:position x="-123.14881" y="157.59032" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Patient Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Patient Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.18738" y="-247.74727" z="0.0"></viz:position>
+        <viz:position x="-298.90405" y="-25.443274" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Provider Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Provider Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="184.85358" y="-236.27737" z="0.0"></viz:position>
+        <viz:position x="111.85695" y="278.35486" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-90.09975" y="-43.384068" z="0.0"></viz:position>
+        <viz:position x="-93.96543" y="-34.209415" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs CA B3,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs CA B3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="53.512417" y="-192.73752" z="0.0"></viz:position>
+        <viz:position x="192.25433" y="-55.12736" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs User CA B1,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs User CA B1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-171.37454" y="-103.10829" z="0.0"></viz:position>
+        <viz:position x="-187.93086" y="68.40612" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI CA 5,O=ORC PKI,C=US" label="WidePoint NFI CA 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="199.78223" y="-223.79019" z="0.0"></viz:position>
+        <viz:position x="233.40355" y="188.46494" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI CA 6,O=ORC PKI,C=US" label="WidePoint NFI CA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="213.87164" y="-210.41289" z="0.0"></viz:position>
+        <viz:position x="12.734353" y="299.71786" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint NFI Root 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="227.04549" y="-196.14543" z="0.0"></viz:position>
+        <viz:position x="169.59428" y="105.982124" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC ECA 7,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="WidePoint ORC ECA 7">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="239.22751" y="-181.01332" z="0.0"></viz:position>
+        <viz:position x="-393.15558" y="73.49255" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint ORC NFI 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="250.44308" y="-165.14366" z="0.0"></viz:position>
+        <viz:position x="261.9257" y="-146.29843" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC SSP 5,O=ORC PKI,C=US" label="WidePoint ORC SSP 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="260.65405" y="-148.58733" z="0.0"></viz:position>
+        <viz:position x="-50.00278" y="-86.60283" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Department of Veterans Affairs CA,OU=Certification Authorities,OU=Department of Veterans Affairs,O=U.S. Government,C=US" label="Department of Veterans Affairs CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="200.01112" y="-1.0881825E-24" z="0.0"></viz:position>
+        <viz:position x="-199.50249" y="-13.951917" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=DHS CA4,OU=Certification Authorities,OU=Department of Homeland Security,O=U.S. Government,C=US" label="DHS CA4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="10.826942" y="-199.73137" z="0.0"></viz:position>
+        <viz:position x="-74.916756" y="185.4385" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services NFI Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services NFI Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="269.65707" y="-131.42062" z="0.0"></viz:position>
+        <viz:position x="34.724426" y="-196.95927" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-22.251541" y="-97.487785" z="0.0"></viz:position>
+        <viz:position x="17.368565" y="-98.49235" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-145.20483" y="-137.52435" z="0.0"></viz:position>
+        <viz:position x="61.809654" y="-190.21974" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust NFI Medium Assurance SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust NFI Medium Assurance SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="277.64273" y="-113.68806" z="0.0"></viz:position>
+        <viz:position x="63.208424" y="293.25812" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Fiscal Service,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Fiscal Service">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-171.37454" y="103.10829" z="0.0"></viz:position>
+        <viz:position x="-176.58812" y="93.90184" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO PCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="284.45856" y="-95.46593" z="0.0"></viz:position>
+        <viz:position x="182.69185" y="-81.35108" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="289.95193" y="-76.86231" z="0.0"></viz:position>
+        <viz:position x="-298.90405" y="25.443274" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=NASA Operational CA,OU=Certification Authorities,OU=NASA,O=U.S. Government,C=US" label="NASA Operational CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="10.826942" y="199.70595" z="0.0"></viz:position>
+        <viz:position x="-161.78662" y="-117.55375" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=OCIO CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury OCIO CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-112.25114" y="165.55055" z="0.0"></viz:position>
+        <viz:position x="6.979933" y="199.88397" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Social Security Administration Certification Authority,OU=SSA,O=U.S. Government,C=US" label="Social Security Administration Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-198.81583" y="21.622095" z="0.0"></viz:position>
+        <viz:position x="199.9857" y="-4.0419217E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=U.S. Department of State PIV CA2,OU=Certification Authorities,OU=PIV,OU=Department of State,O=U.S. Government,C=US" label="U.S. Department of State PIV CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="93.672966" y="176.68985" z="0.0"></viz:position>
+        <viz:position x="-74.92946" y="-185.46393" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="62.356445" y="-78.184784" z="0.0"></viz:position>
+        <viz:position x="76.595276" y="-64.2734" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services NFI Root CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="294.32626" y="-57.931255" z="0.0"></viz:position>
+        <viz:position x="-499.9706" y="6.124248E-14" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="297.47986" y="-38.755417" z="0.0"></viz:position>
+        <viz:position x="-353.5323" y="-353.5323" z="0.0"></viz:position>
+        <viz:color r="153" g="0" b="153"></viz:color>
+      </node>
+      <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US">
+        <attvalues></attvalues>
+        <viz:size value="10.0"></viz:size>
+        <viz:position x="-9.184962E-14" y="-499.9706" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Australian Defence Interoperability CA,OU=CAs,OU=PKI,OU=DoD,O=GOV,C=AU">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.36182" y="-19.419035" z="0.0"></viz:position>
+        <viz:position x="353.5323" y="-353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
     </nodes>
@@ -1140,38 +1140,6 @@
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>
-      <edge id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=ORC SSP 4,O=ORC PKI,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA" weight="2.0">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
-      <edge id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA" weight="2.0">
-        <viz:color r="153" g="0" b="153"></viz:color>
-        <attvalues></attvalues>
-      </edge>
       <edge id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" source="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" target="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
@@ -1465,6 +1433,34 @@
         <attvalues></attvalues>
       </edge>
       <edge id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" source="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com" target="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=ORC SSP 4,O=ORC PKI,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA" weight="2.0">
+        <viz:color r="153" g="0" b="153"></viz:color>
+        <attvalues></attvalues>
+      </edge>
+      <edge id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" source="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US" target="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA" weight="2.0">
         <viz:color r="153" g="0" b="153"></viz:color>
         <attvalues></attvalues>
       </edge>


### PR DESCRIPTION
@idmken 

Please find this week's Federal PKI Crawler/Graph update (February 9, 2021 execution). 

<br>

**Live Preview:** https://federalist-2147738e-703c-4833-9101-89d779f09ce1.app.cloud.gov/preview/gsa/fpki-guides/20210209-auto-fpki-graph-update/tools/fpkigraph/

<br>

**Nodes Added or Removed (compared to February 3, 2021 execution):**
- N1 (ADDED): CN=WidePoint NFI CA 6,O=ORC PKI,C=US
 
<br>

**Edges Added or Removed (compared to February 3, 2021 execution):**
- E1 (ADDED): CN=WidePoint NFI Root 2, OU=Certification Authorities, O=WidePoint, C=US -> CN=WidePoint NFI CA 6, O=ORC PKI, C=US
   
<br>

**Root Cause Analysis:**
- E1/N1:  New certificate detected.  Certificate details:
     - Subject: CN=WidePoint NFI CA 6, O=ORC PKI, C=US 
     - Issuer: CN=WidePoint NFI Root 2, OU=Certification Authorities, O=WidePoint, C=US 
     - Validity: February 3, 2021 to December 31, 2030 
     - Serial: 15707f8b78d4594f0fdc0d7884241c7659dd83e3   
     - SHA1 Hash: 8a17d236acb45af809c0a4555f7142d82ae08736   
     - Key Size: 2048-bit RSA
     - Signing Algorithm: SHA-256 with RSA

<br>

**Other updates:**
- Add a System Notification to close #814
- Common Policy Playbook Updates:
	- Added more clarity surrounding when intermediate CA certificates should be distributed
	- Added an additional reference to the Entrust link certificate on Step 6 (distribute intermediate CA certificates) for improved visibility
	- Added the next webinar date (planned for 2/17/21)
	- Added RHEL trust store configuration instructions provided by DOI (#827)
	
	