### PR TITLE
auto fpki graph update (20210309)

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3500,6 +3500,49 @@
   sia_uri:
   ocsp_uri:  
   
+- notice_date: March 2, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the CertiPath Bridge CA - G2 from the Federal Bridge CA G4. The revocation is planned to take place on or around March 18, 2021.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 3bfc4df881682f8846bff486d422025aee7494d8  
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US 
+  ca_certificate_subject: CN=CertiPath Bridge CA - G2, OU=Certification Authorities, O=CertiPath LLC, C=US     
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl  
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c 
+  sia_uri: http://certipath-sia.symauth.com/IssuedBy-CertiPathBridgeCA-G2.p7c  
+  ocsp_uri:   
+  
+- notice_date: March 2, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the SAFE Bridge CA 02 from the Federal Bridge CA G4.  The revocation is planned to take place on or around March 18, 2021.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 600319e6c322229f88e0f434ba96fb0dfd00252e   
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US   
+  ca_certificate_subject: CN=SAFE Bridge CA 02, OU=Certification Authorities, O=SAFE-Biopharma, C=US    
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl   
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c  
+  sia_uri: http://sbca2.safe-biopharma.org/sbca/issuedbySBCA02.p7c 
+  ocsp_uri:   
+  
+  
+- notice_date: March 2, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the Federal Common Policy CA from the Federal Bridge CA G4.  The revocation is planned for mid-May. 
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash:   
+  ca_certificate_issuer:  
+  ca_certificate_subject:    
+  cdp_uri:  
+  aia_uri:  
+  sia_uri:  
+  ocsp_uri:   
+  
  - notice_date: March 5, 2021
   change_type: Intent to Decommission CA
   system: FPKI Trust Infrastructure - Federal Common Policy CA

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3535,12 +3535,12 @@
   system: FPKI Trust Infrastructure - Federal Bridge CA G4
   change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the Federal Common Policy CA from the Federal Bridge CA G4.  The revocation is planned for mid-May. 
   contact: fpki dash help at gsa dot gov
-  ca_certificate_hash:   
-  ca_certificate_issuer:  
-  ca_certificate_subject:    
-  cdp_uri:  
-  aia_uri:  
-  sia_uri:  
+  ca_certificate_hash: fb3f5e09cac4fe4066f6c48cce31feca02fea677  
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US    
+  ca_certificate_subject: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US    
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl  
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c 
+  sia_uri: http://http.fpki.gov/fcpca/caCertsIssuedByfcpca.p7c  
   ocsp_uri:   
   
 - notice_date: March 5, 2021

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3543,7 +3543,7 @@
   sia_uri:  
   ocsp_uri:   
   
- - notice_date: March 5, 2021
+- notice_date: March 5, 2021
   change_type: Intent to Decommission CA
   system: FPKI Trust Infrastructure - Federal Common Policy CA
   change_description: The Federal PKI Management Authority is preparing to decommission the Federal Common Policy CA (planned for May 2021).  Valid CA certificates issued by the Federal Common Policy CA will be revoked prior to decommissioning.  This notice was first posted on September 25, 2020.

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3548,12 +3548,12 @@
   system: FPKI Trust Infrastructure - Federal Common Policy CA
   change_description: The Federal PKI Management Authority is preparing to decommission the Federal Common Policy CA (planned for May 2021).  Valid CA certificates issued by the Federal Common Policy CA will be revoked prior to decommissioning.  This notice was first posted on September 25, 2020.
   contact: fpki dash help at gsa dot gov
-  ca_certificate_hash:  
+  ca_certificate_hash: 905f942fd9f28f679b378180fd4f846347f645c1 
   ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
   ca_certificate_subject: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
   cdp_uri: 
   aia_uri: 
-  sia_uri: 
+  sia_uri: http://http.fpki.gov/fcpca/caCertsIssuedByfcpca.p7c 
   ocsp_uri:
  
 - notice_date: March 5, 2021

--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -3499,6 +3499,89 @@
   aia_uri:  
   sia_uri:
   ocsp_uri:  
+  
+ - notice_date: March 5, 2021
+  change_type: Intent to Decommission CA
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority is preparing to decommission the Federal Common Policy CA (planned for May 2021).  Valid CA certificates issued by the Federal Common Policy CA will be revoked prior to decommissioning.  This notice was first posted on September 25, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash:  
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  cdp_uri: 
+  aia_uri: 
+  sia_uri: 
+  ocsp_uri:
+ 
+- notice_date: March 5, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the Entrust Managed Services Root CA from the Federal Common Policy CA on April 22, 2021.  An updated certificate was issued by the Federal Common Policy CA G2 on November 18, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 39c1d3b64e756a3267bfe5fecb103da892ca0611 
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: OU=Entrust Managed Services Root CA, OU=Certification Authorities, O=Entrust, C=US  
+  cdp_uri: http://http.fpki.gov/fcpca/fcpca.crl  
+  aia_uri: http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c  
+  sia_uri: http://rootweb.managed.entrust.com/SIA/CertsIssuedByEMSRootCA.p7c
+  ocsp_uri:    
+
+- notice_date: March 5, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the Entrust Managed Services Root CA from the Federal Common Policy CA on April 22, 2021.  An updated certificate was issued by the Federal Common Policy CA G2 on November 18, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: a09655170c87d0fbfe0328b99a7baf4a1cf0b5d9  
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: OU=Entrust Managed Services Root CA, OU=Certification Authorities, O=Entrust, C=US  
+  cdp_uri: http://http.fpki.gov/fcpca/fcpca.crl 
+  aia_uri: http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c  
+  sia_uri: http://rootweb.managed.entrust.com/SIA/CertsIssuedByEMSRootCA.p7c
+  ocsp_uri:  
+
+- notice_date: March 9, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to ORC SSP 4 from the Federal Common Policy CA on April 22, 2021.  An updated certificate was issued by the Federal Common Policy CA G2 on November 18, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 3a70323069a4c41bc95663152e9ccc7111bb0623 
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=ORC SSP 4, O=ORC PKI, C=US 
+  cdp_uri: http://http.fpki.gov/fcpca/fcpca.crl 
+  aia_uri: http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c  
+  sia_uri: http://crlserver.orc.com/caCerts/ORCSSP4.p7c
+  ocsp_uri:    
+
+- notice_date: March 9, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to Verizon SSP CA A2 from the Federal Common Policy CA on April 22, 2021.  An updated certificate was issued by the Federal Common Policy CA G2 on November 18, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: 477bf4017d25cde276cdddf756d40ca591d76f6d  
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=Verizon SSP CA A2, OU=SSP, O=Verizon, C=US 
+  cdp_uri: http://http.fpki.gov/fcpca/fcpca.crl 
+  aia_uri: http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c  
+  sia_uri: http://sia1.ssp-strong-id.net/CA/VZ-SSP-CA-A2-SIA.p7c
+  ocsp_uri:    
+
+- notice_date: March 10, 2021
+  change_type: Intent to Perform CA Certificate Revocation
+  start_datetime:
+  system: FPKI Trust Infrastructure - Federal Common Policy CA
+  change_description: The Federal PKI Management Authority intends to revoke the certificate issued to the U.S. Department of State AD Root CA from the Federal Common Policy CA on April 22, 2021.  An updated certificate was issued by the Federal Common Policy CA G2 on November 18, 2020.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: ce11590010562a39ad8b1455acf76c03737aebf6 
+  ca_certificate_issuer: CN=Federal Common Policy CA, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=U.S. Department of State AD Root CA, CN=AIA, CN=Public Key Services, CN=Services, CN=Configuration, DC=state, DC=sbu
+  cdp_uri: http://http.fpki.gov/fcpca/fcpca.crl  
+  aia_uri: http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c 
+  sia_uri: http://crls.pki.state.gov/SIA/CertsIssuedByADRootCA.p7c
+  ocsp_uri:    
 
 #- notice_date:  
 #  change_type: CA Certificate Issuance

--- a/_tools/01_fpki_graph.md
+++ b/_tools/01_fpki_graph.md
@@ -4,7 +4,7 @@ title: Federal PKI Graph
 collection: tools
 permalink: tools/fpkigraph/
 ---
-**Last Update**: March 02, 2021
+**Last Update**: March 09, 2021
 {% include graph.html %}
 
 The FPKI Graph displays the relationships between the Certification Authorities in the Federal PKI (FPKI) ecosystem. It graphically depicts how each Certification Authority links to another, through cross-certificates, subordinate certificates, or Bridge CAs.  

--- a/_tools/fpki-certs.gexf
+++ b/_tools/fpki-certs.gexf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd">
-  <meta lastmodifieddate="2021-03-02">
+  <meta lastmodifieddate="2021-03-09">
     <creator>Gephi 0.8.1</creator>
     <description></description>
   </meta>
@@ -9,25 +9,25 @@
       <node id="CN=Alexion Pharmaceuticals Issue 2 CA,OU=CAs,O=Alexion Pharmaceuticals,C=US" label="Alexion Pharmaceuticals Issue 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.44528" y="-52.100933" z="0.0"></viz:position>
+        <viz:position x="-295.44528" y="-52.094578" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Boeing PCA G3,OU=certservers,O=Boeing,C=US" label="Boeing PCA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-259.84024" y="150.01152" z="0.0"></viz:position>
+        <viz:position x="-259.7894" y="149.9861" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Booz Allen Hamilton PIVi CA 01,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="Booz Allen Hamilton PIVi CA 01">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-229.81761" y="-192.86469" z="0.0"></viz:position>
+        <viz:position x="-229.84303" y="-192.86469" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Bureau of the Census Agency CA,OU=Department of Commerce,O=U.S. Government,C=US" label="Bureau of the Census Agency CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-143.85695" y="-138.92311" z="0.0"></viz:position>
+        <viz:position x="-143.88237" y="-138.92311" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon Federal Services PIV-I CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA1">
@@ -39,7 +39,7 @@
       <node id="CN=Carillon Federal Services PIV-I CA2,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US" label="Carillon Federal Services PIV-I CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="150.01152" y="-259.84024" z="0.0"></viz:position>
+        <viz:position x="149.9861" y="-259.84024" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Carillon PKI Services G2 Root CA 2,OU=Certification Authorities,O=Carillon Information Security Inc.,C=CA" label="Carillon PKI Services G2 Root CA 2">
@@ -57,7 +57,7 @@
       <node id="CN=CertiPath Bridge CA - G2,OU=Certification Authorities,O=CertiPath LLC,C=US" label="CertiPath Bridge CA - G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-99.99285" y="-173.20566" z="0.0"></viz:position>
+        <viz:position x="-100.00556" y="-173.23106" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=CertiPath Bridge CA - G3,OU=Certification Authorities,O=CertiPath,C=US" label="CertiPath Bridge CA - G3">
@@ -69,13 +69,13 @@
       <node id="CN=DigiCert Class 3 SSP Intermediate CA - G4,O=DigiCert,Inc.,C=US" label="DigiCert Class 3 SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-99.99285" y="173.20566" z="0.0"></viz:position>
+        <viz:position x="-100.00556" y="173.20566" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federal SSP Intermediate CA - G5,O=DigiCert,Inc.,C=US" label="DigiCert Federal SSP Intermediate CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="100.00556" y="-3.677361E-24" z="0.0"></viz:position>
+        <viz:position x="100.00556" y="7.2191634E-25" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DigiCert Federated ID L3 CA,OU=www.digicert.com,O=DigiCert Inc,C=US" label="DigiCert Federated ID L3 CA">
@@ -93,13 +93,13 @@
       <node id="CN=DOD DERILITY CA-1,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD DERILITY CA-1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-399.9714" y="4.043077E-13" z="0.0"></viz:position>
+        <viz:position x="-399.9714" y="4.0426256E-13" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-41">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-372.96246" y="-144.51817" z="0.0"></viz:position>
+        <viz:position x="-372.96246" y="-144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-42">
@@ -117,13 +117,13 @@
       <node id="CN=DOD EMAIL CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="340.05325" y="210.56548" z="0.0"></viz:position>
+        <viz:position x="340.05325" y="210.5909" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-49">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="372.96246" y="144.49275" z="0.0"></viz:position>
+        <viz:position x="373.0133" y="144.49275" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-50,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-50">
@@ -135,7 +135,7 @@
       <node id="CN=DOD EMAIL CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.05862" y="319.1989" z="0.0"></viz:position>
+        <viz:position x="241.08403" y="319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD EMAIL CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-52">
@@ -147,7 +147,7 @@
       <node id="CN=DOD EMAIL CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD EMAIL CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-109.466324" y="-384.76294" z="0.0"></viz:position>
+        <viz:position x="-109.466324" y="-384.71213" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-41,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-41">
@@ -159,7 +159,7 @@
       <node id="CN=DOD ID CA-42,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-42">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-295.6487" y="269.4536" z="0.0"></viz:position>
+        <viz:position x="-295.59787" y="269.4536" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-43,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-43">
@@ -171,7 +171,7 @@
       <node id="CN=DOD ID CA-44,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-44">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="36.911583" y="398.29288" z="0.0"></viz:position>
+        <viz:position x="36.905228" y="398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-49,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-49">
@@ -189,7 +189,7 @@
       <node id="CN=DOD ID CA-51,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-51">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-36.905228" y="398.29288" z="0.0"></viz:position>
+        <viz:position x="-36.911583" y="398.29288" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID CA-52,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-52">
@@ -201,7 +201,7 @@
       <node id="CN=DOD ID CA-59,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID CA-59">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-340.05325" y="210.5909" z="0.0"></viz:position>
+        <viz:position x="-340.1041" y="210.5909" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD ID SW CA-37,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD ID SW CA-37">
@@ -231,7 +231,7 @@
       <node id="CN=DoD Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Interoperability Root CA 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-48.381485" y="-194.08543" z="0.0"></viz:position>
+        <viz:position x="-48.387836" y="-194.06001" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DoD Root CA 3,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DoD Root CA 3">
@@ -249,7 +249,7 @@
       <node id="CN=DOD SW CA-54,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-54">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-393.15558" y="73.49255" z="0.0"></viz:position>
+        <viz:position x="-393.15558" y="73.505264" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=DOD SW CA-60,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="DOD SW CA-60">
@@ -261,7 +261,7 @@
       <node id="CN=DOE SSP CA,OU=Certification Authorities,OU=Department of Energy,O=U.S. Government,C=US" label="DOE SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-143.88237" y="138.92311" z="0.0"></viz:position>
+        <viz:position x="-143.85695" y="138.94853" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ECA Root CA 4,OU=ECA,O=U.S. Government,C=US" label="ECA Root CA 4">
@@ -273,7 +273,7 @@
       <node id="CN=Eid Passport LRA 2 CA,OU=Eid Passport PIV-I LRA Network,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA 2 CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="259.84024" y="-149.9861" z="0.0"></viz:position>
+        <viz:position x="259.7894" y="-149.9861" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Eid Passport LRA CA 3,OU=RAPIDGate PIV Interoperable LRA,O=Eid Passport,Inc.,C=US" label="Eid Passport LRA CA 3">
@@ -285,13 +285,13 @@
       <node id="CN=Entrust Derived Credential SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Derived Credential SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="153.19055" y="128.5468" z="0.0"></viz:position>
+        <viz:position x="153.21597" y="128.5468" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Digital Certificate Service Signing CA 1,O=Exostar UK Limited,C=GB" label="Exostar Digital Certificate Service Signing CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="259.7894" y="150.01152" z="0.0"></viz:position>
+        <viz:position x="259.7894" y="149.9861" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Exostar Federated Identity Service Root CA 2,OU=Certification Authorities,O=Exostar LLC,C=US" label="Exostar Federated Identity Service Root CA 2">
@@ -303,43 +303,43 @@
       <node id="CN=Exostar Federated Identity Service Signing CA 3,DC=evincible,DC=com" label="Exostar Federated Identity Service Signing CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-8.544245E-13" y="-299.9722" z="0.0"></viz:position>
+        <viz:position x="-8.545148E-13" y="-299.9722" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Bridge CA G4,OU=FPKI,O=U.S. Government,C=US" label="Federal Bridge CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="76.60799" y="64.2734" z="0.0"></viz:position>
+        <viz:position x="76.595276" y="64.28611" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA G2,OU=FPKI,O=U.S. Government,C=US" label="Federal Common Policy CA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="2.1846986E-24" y="-2.2945345E-24" z="0.0"></viz:position>
+        <viz:position x="3.865778E-24" y="4.254521E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions Intermediate CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions Intermediate CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="499.9706" y="3.612992E-24" z="0.0"></viz:position>
+        <viz:position x="499.9706" y="-3.854857E-24" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Fortior Solutions PKI Root CA 2018,OU=Certificate Authorities,O=Fortior Solutions,C=US" label="Fortior Solutions PKI Root CA 2018">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="353.5323" y="353.5323" z="0.0"></viz:position>
+        <viz:position x="353.5323" y="353.58313" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=FTI Certification Authority,OU=FTI PKI Trust Infrastructure,O=Foundation for Trusted Identity,C=US" label="FTI Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.83926" y="-229.84303" z="0.0"></viz:position>
+        <viz:position x="192.83926" y="-229.81761" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=HHS-FPKI-Intermediate-CA-E1,OU=Certification Authorities,OU=HHS,O=U.S. Government,C=US" label="HHS-FPKI-Intermediate-CA-E1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="111.83151" y="165.8303" z="0.0"></viz:position>
+        <viz:position x="111.84422" y="165.8049" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA Component S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA Component S21">
@@ -351,7 +351,7 @@
       <node id="CN=IdenTrust ECA S21,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S21">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="241.08403" y="-319.1989" z="0.0"></viz:position>
+        <viz:position x="241.05862" y="-319.1989" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust ECA S22,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22">
@@ -363,7 +363,7 @@
       <node id="CN=IdenTrust ECA S22C,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="IdenTrust ECA S22C">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="109.466324" y="-384.71213" z="0.0"></viz:position>
+        <viz:position x="109.466324" y="-384.76294" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IdenTrust Global Common Root CA 1,O=IdenTrust,C=US" label="IdenTrust Global Common Root CA 1">
@@ -381,13 +381,13 @@
       <node id="CN=IGC CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-299.9722" y="4.3642826E-13" z="0.0"></viz:position>
+        <viz:position x="-299.9722" y="4.3647342E-13" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=IGC Server CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="IGC Server CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.83926" y="229.84303" z="0.0"></viz:position>
+        <viz:position x="192.86469" y="229.81761" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Leidos FBCA Cloud PKI CA-1,O=Leidos" label="Leidos FBCA Cloud PKI CA-1">
@@ -405,37 +405,37 @@
       <node id="CN=Lockheed Martin Root Certification Authority 2,OU=Certification Authorities,O=Lockheed Martin Corporation,L=Denver,ST=Colorado,C=US" label="Lockheed Martin Root Certification Authority 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-102.59965" y="281.91537" z="0.0"></viz:position>
+        <viz:position x="-102.59965" y="281.96622" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3,OID.2.5.4.97=NTRNL-27370985,O=Ministerie van Defensie,C=NL" label="Ministerie van Defensie PKIoverheid Organisatie Persoon CA - G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-259.7894" y="-149.9861" z="0.0"></viz:position>
+        <viz:position x="-259.7894" y="-150.01152" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Agency CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Agency CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.6197" y="-105.982124" z="0.0"></viz:position>
+        <viz:position x="169.59428" y="-105.99483" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Naval Reactors SSP Device CA G3,OU=U.S. Department of Energy,O=U.S. Government,C=US" label="Naval Reactors SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-187.95628" y="68.40612" z="0.0"></viz:position>
+        <viz:position x="-187.95628" y="68.41883" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Root CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Root CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="150.01152" y="259.7894" z="0.0"></viz:position>
+        <viz:position x="149.9861" y="259.84024" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Northrop Grumman Corporate Signing CA-G2,OU=Northrop Grumman Information Technology,O=Northrop Grumman Corporation,C=US" label="Northrop Grumman Corporate Signing CA-G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="399.9714" y="-2.4855763E-24" z="0.0"></viz:position>
+        <viz:position x="399.9714" y="-1.02033346E-25" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Agency CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G3">
@@ -447,19 +447,19 @@
       <node id="CN=NRC SSP Agency CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.81203" y="117.55375" z="0.0"></viz:position>
+        <viz:position x="-161.78662" y="117.55375" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G3,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-123.13611" y="-157.61572" z="0.0"></viz:position>
+        <viz:position x="-123.14881" y="-157.59032" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=NRC SSP Device CA G4,OU=U.S. Nuclear Regulatory Commission,O=U.S. Government,C=US" label="NRC SSP Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-74.916756" y="185.46393" z="0.0"></viz:position>
+        <viz:position x="-74.916756" y="185.4385" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC ECA 6,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="ORC ECA 6">
@@ -471,13 +471,13 @@
       <node id="CN=ORC NFI CA 3,O=ORC PKI,C=US" label="ORC NFI CA 3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="229.81761" y="-192.86469" z="0.0"></viz:position>
+        <viz:position x="229.81761" y="-192.83926" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=ORC SSP 4,O=ORC PKI,C=US" label="ORC SSP 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="17.362213" y="98.47964" z="0.0"></viz:position>
+        <viz:position x="17.368565" y="98.47964" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Class 3 MASCA,OU=Class3-g2,O=cas,DC=raytheon,DC=com" label="Raytheon Class 3 MASCA">
@@ -495,7 +495,7 @@
       <node id="CN=SAFE Identity Bridge CA,OU=Certification Authorities,O=SAFE Identity,C=US" label="SAFE Identity Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="198.05286" y="-27.833897" z="0.0"></viz:position>
+        <viz:position x="198.07828" y="-27.837074" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Senate PIV-I CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I CA G4">
@@ -507,25 +507,25 @@
       <node id="CN=Senate PIV-I Device CA G4,OU=Office of the Sergeant at Arms,OU=U.S. Senate,O=U.S. Government,C=US" label="Senate PIV-I Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-149.9861" y="259.7894" z="0.0"></viz:position>
+        <viz:position x="-149.9861" y="259.84024" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=STRAC Bridge Root Certification Authority,OU=STRAC PKI Trust Infrastructure,O=STRAC,C=US" label="STRAC Bridge Root Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="133.81125" y="148.63818" z="0.0"></viz:position>
+        <viz:position x="133.81125" y="148.61276" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. CA1,OU=SureID PIV-I,O=SureID,Inc.,C=US" label="SureID Inc. CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.91537" y="-102.61236" z="0.0"></viz:position>
+        <viz:position x="-281.91537" y="-102.59965" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=SureID Inc. Device CA2,O=SureID,Inc.,C=US" label="SureID Inc. Device CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="299.9722" y="-1.0114612E-24" z="0.0"></viz:position>
+        <viz:position x="299.9722" y="6.8205727E-25" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Symantec Class 3 SSP Intermediate CA - G3,OU=Symantec Trust Network,O=Symantec Corporation,C=US" label="Symantec Class 3 SSP Intermediate CA - G3">
@@ -537,13 +537,13 @@
       <node id="CN=Symantec SSP Intermediate CA - G4,O=Symantec Corporation,C=US" label="Symantec SSP Intermediate CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-50.00278" y="86.60283" z="0.0"></viz:position>
+        <viz:position x="-49.996426" y="86.61553" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Mobile eIDAS QCA G2,OU=Individual Subscriber CA,O=Trans Sped SRL,C=RO" label="Trans Sped Mobile eIDAS QCA G2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="102.61236" y="-281.96622" z="0.0"></viz:position>
+        <viz:position x="102.59965" y="-281.91537" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Trans Sped Root CA G2,OU=Trans Sped CA,O=Trans Sped SRL,C=RO" label="Trans Sped Root CA G2">
@@ -555,13 +555,13 @@
       <node id="CN=TSCP SHA256 Bridge CA,OU=CAs,O=TSCP Inc.,C=US" label="TSCP SHA256 Bridge CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="111.83151" y="-165.8303" z="0.0"></viz:position>
+        <viz:position x="111.84422" y="-165.8049" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="192.25433" y="55.133717" z="0.0"></viz:position>
+        <viz:position x="192.27974" y="55.12736" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Agency CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Agency CA - G5">
@@ -573,49 +573,49 @@
       <node id="CN=U.S. Department of Education Device CA - G4,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-20.903637" y="-198.89212" z="0.0"></viz:position>
+        <viz:position x="-20.906815" y="-198.91754" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Education Device CA - G5,OU=U.S. Department of Education,O=U.S. Government,C=US" label="U.S. Department of Education Device CA - G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="87.670975" y="-179.74171" z="0.0"></viz:position>
+        <viz:position x="87.670975" y="-179.76714" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD High Assurance CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD High Assurance CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-176.58812" y="93.88914" z="0.0"></viz:position>
+        <viz:position x="-176.61354" y="93.90184" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of State AD Root CA,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=state,DC=sbu" label="U.S. Department of State AD Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.97814" y="34.20306" z="0.0"></viz:position>
+        <viz:position x="-93.97814" y="34.209415" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-199.50249" y="13.950328" z="0.0"></viz:position>
+        <viz:position x="-199.50249" y="13.951917" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Agency CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Agency CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="61.809654" y="190.21974" z="0.0"></viz:position>
+        <viz:position x="61.8033" y="190.19432" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G4,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-48.387836" y="194.06001" z="0.0"></viz:position>
+        <viz:position x="-48.387836" y="194.08543" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=U.S. Department of Transportation Device CA G5,OU=U.S. Department of Transportation,O=U.S. Government,C=US" label="U.S. Department of Transportation Device CA G5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-199.52791" y="-13.950328" z="0.0"></viz:position>
+        <viz:position x="-199.52791" y="-13.951917" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=US DoD CCEB Interoperability Root CA 2,OU=PKI,OU=DoD,O=U.S. Government,C=US" label="US DoD CCEB Interoperability Root CA 2">
@@ -627,7 +627,7 @@
       <node id="CN=USPTO_INTR_CA1,CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=uspto,DC=gov" label="USPTO_INTR_CA1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-20.903637" y="198.91754" z="0.0"></viz:position>
+        <viz:position x="-20.906815" y="198.89212" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=VA Patient Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Patient Direct CA 1">
@@ -639,25 +639,25 @@
       <node id="CN=VA Provider Direct CA 1,OU=IdenTrust Global Common,O=IdenTrust,C=US" label="VA Provider Direct CA 1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="52.094578" y="295.44528" z="0.0"></viz:position>
+        <viz:position x="52.100933" y="295.44528" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Verizon SSP CA A2,OU=SSP,O=Verizon,C=US" label="Verizon SSP CA A2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-93.97814" y="-34.209415" z="0.0"></viz:position>
+        <viz:position x="-93.97814" y="-34.20306" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs CA B3,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs CA B3">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="6.979933" y="199.9094" z="0.0"></viz:position>
+        <viz:position x="6.980727" y="199.88397" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Veterans Affairs User CA B1,OU=PKI,OU=Services,DC=va,DC=gov" label="Veterans Affairs User CA B1">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="199.9857" y="1.8137717E-24" z="0.0"></viz:position>
+        <viz:position x="199.9857" y="-7.8040683E-25" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI CA 5,O=ORC PKI,C=US" label="WidePoint NFI CA 5">
@@ -669,13 +669,13 @@
       <node id="CN=WidePoint NFI CA 6,O=ORC PKI,C=US" label="WidePoint NFI CA 6">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-52.094578" y="295.49612" z="0.0"></viz:position>
+        <viz:position x="-52.094578" y="295.44528" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint NFI Root 2,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint NFI Root 2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-161.78662" y="-117.55375" z="0.0"></viz:position>
+        <viz:position x="-161.81203" y="-117.56646" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC ECA 7,OU=Certification Authorities,OU=ECA,O=U.S. Government,C=US" label="WidePoint ORC ECA 7">
@@ -687,31 +687,31 @@
       <node id="CN=WidePoint ORC NFI 4,OU=Certification Authorities,O=WidePoint,C=US" label="WidePoint ORC NFI 4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="281.91537" y="-102.61236" z="0.0"></viz:position>
+        <viz:position x="281.96622" y="-102.61236" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=WidePoint ORC SSP 5,O=ORC PKI,C=US" label="WidePoint ORC SSP 5">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-50.00278" y="-86.60283" z="0.0"></viz:position>
+        <viz:position x="-49.996426" y="-86.61553" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Department of Veterans Affairs CA,OU=Certification Authorities,OU=Department of Veterans Affairs,O=U.S. Government,C=US" label="Department of Veterans Affairs CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-187.93086" y="-68.40612" z="0.0"></viz:position>
+        <viz:position x="-187.93086" y="-68.41883" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=DHS CA4,OU=Certification Authorities,OU=Department of Homeland Security,O=U.S. Government,C=US" label="DHS CA4">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="34.73713" y="-196.9847" z="0.0"></viz:position>
+        <viz:position x="34.73713" y="-196.95927" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services NFI Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services NFI Root CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="34.724426" y="196.95927" z="0.0"></viz:position>
+        <viz:position x="34.73713" y="196.9847" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Entrust Managed Services Root CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust Managed Services Root CA">
@@ -729,7 +729,7 @@
       <node id="OU=Entrust NFI Medium Assurance SSP CA,OU=Certification Authorities,O=Entrust,C=US" label="Entrust NFI Medium Assurance SSP CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="229.84303" y="192.83926" z="0.0"></viz:position>
+        <viz:position x="229.81761" y="192.83926" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Fiscal Service,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Fiscal Service">
@@ -741,13 +741,13 @@
       <node id="OU=GPO PCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO PCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="61.809654" y="-190.19432" z="0.0"></viz:position>
+        <viz:position x="61.8033" y="-190.19432" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=GPO SCA,OU=Certification Authorities,OU=Government Printing Office,O=U.S. Government,C=US" label="GPO SCA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-281.96622" y="102.59965" z="0.0"></viz:position>
+        <viz:position x="-281.91537" y="102.61236" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=NASA Operational CA,OU=Certification Authorities,OU=NASA,O=U.S. Government,C=US" label="NASA Operational CA">
@@ -759,19 +759,19 @@
       <node id="OU=OCIO CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury OCIO CA">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="169.6197" y="105.99483" z="0.0"></viz:position>
+        <viz:position x="169.59428" y="105.99483" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=Social Security Administration Certification Authority,OU=SSA,O=U.S. Government,C=US" label="Social Security Administration Certification Authority">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="6.980727" y="-199.9094" z="0.0"></viz:position>
+        <viz:position x="6.980727" y="-199.88397" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=U.S. Department of State PIV CA2,OU=Certification Authorities,OU=PIV,OU=Department of State,O=U.S. Government,C=US" label="U.S. Department of State PIV CA2">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-195.61137" y="-41.58474" z="0.0"></viz:position>
+        <viz:position x="-195.61137" y="-41.578384" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="OU=US Treasury Root CA,OU=Certification Authorities,OU=Department of the Treasury,O=U.S. Government,C=US" label="US Treasury Root CA">
@@ -783,19 +783,19 @@
       <node id="CN=Carillon Federal Services NFI Root CA1,OU=Certification Authorities,O=Carillon Federal Services Inc.,C=US">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-499.9706" y="6.124248E-14" z="0.0"></viz:position>
+        <viz:position x="-499.9706" y="6.12312E-14" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Raytheon Root CA,OU=RaytheonRoot-g2,O=CAs,DC=raytheon,DC=com">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-353.58313" y="-353.58313" z="0.0"></viz:position>
+        <viz:position x="-353.5323" y="-353.5323" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Federal Common Policy CA,OU=FPKI,O=U.S. Government,C=US">
         <attvalues></attvalues>
         <viz:size value="10.0"></viz:size>
-        <viz:position x="-9.184962E-14" y="-499.9706" z="0.0"></viz:position>
+        <viz:position x="-9.1860906E-14" y="-499.9706" z="0.0"></viz:position>
         <viz:color r="153" g="0" b="153"></viz:color>
       </node>
       <node id="CN=Australian Defence Interoperability CA,OU=CAs,OU=PKI,OU=DoD,O=GOV,C=AU">


### PR DESCRIPTION
@idmken 

Please find this week's Federal PKI Crawler/Graph update (March 9, 2021 execution). 

<br>

**Live Preview:** https://federalist-2147738e-703c-4833-9101-89d779f09ce1.app.cloud.gov/preview/gsa/fpki-guides/20210309-auto-fpki-graph-update/tools/fpkigraph/

<br>

**Nodes Added or Removed (compared to March 2, 2021 execution):**
- No change.
<br>

**Edges Added or Removed (compared to March 2, 2021 execution):**
- No change.



<br>

**Root Cause Analysis:**
- N/A - no change.
<br>

**Other updates:**
- System Notifications (all new issues should remain open until certificate operations are complete):
	- Added Issue #843 - and added system notifications for the intent to perform revocation.
	- Added Issue #842 - and added (again) a system notification for the planned Federal Common Policy CA decommissioning
	- Added Issue #841 - and notifications for CAs that have confirmed a revocation date.
	
	
